### PR TITLE
Restore null safe equalsIgnoreCase helper

### DIFF
--- a/android/src/main/java/org/jellyfin/apiclient/interaction/VolleyHttpClient.java
+++ b/android/src/main/java/org/jellyfin/apiclient/interaction/VolleyHttpClient.java
@@ -96,10 +96,10 @@ public class VolleyHttpClient implements IAsyncHttpClient {
     {
         int method = Request.Method.GET;
 
-        if (request.getMethod().equalsIgnoreCase("POST")) {
+        if ("POST".equalsIgnoreCase(request.getMethod())) {
             method = Request.Method.POST;
         }
-        else if (request.getMethod().equalsIgnoreCase("DELETE")) {
+        else if ("DELETE".equalsIgnoreCase(request.getMethod())) {
             method = Request.Method.DELETE;
         }
 
@@ -130,7 +130,6 @@ public class VolleyHttpClient implements IAsyncHttpClient {
     }
 
     public void getBitmap(String url, final Response<Bitmap> outerResponse) {
-
         getImageLoader().get(url, new GetBitmapResponse(outerResponse));
     }
 }

--- a/android/src/main/java/org/jellyfin/apiclient/interaction/VolleyStringRequest.java
+++ b/android/src/main/java/org/jellyfin/apiclient/interaction/VolleyStringRequest.java
@@ -11,6 +11,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class VolleyStringRequest extends StringRequest {
+    /* HTTP Headers */
+    private static final String AUTHORIZATION_HEADER = "X-Emby-Authorization";
+    private static final String CONTENT_TYPE_HEADER = "Content-Type";
+    /* Content Types */
+    private static final String JSON_TYPE = "application/json";
+    private static final String TEXT_TYPE = "text/plain";
+    private static final String VTT_TYPE = "text/vtt";
 
     private HttpRequest request;
 
@@ -60,7 +67,6 @@ public class VolleyStringRequest extends StringRequest {
      * @throws AuthFailureError in the event of auth failure
      */
     public byte[] getBody() throws AuthFailureError {
-
         String postContent = request.getRequestContent();
 
         if (postContent == null) {
@@ -72,18 +78,11 @@ public class VolleyStringRequest extends StringRequest {
 
     @Override
     protected com.android.volley.Response<String> parseNetworkResponse(NetworkResponse response) {
-
-        String contentType = response.headers.get("Content-Type");
+        String contentType = response.headers.get(CONTENT_TYPE_HEADER);
 
         // This is a hack to make volley decode in UTF-8
-        if (contentType.equalsIgnoreCase("application/json")) {
-            response.headers.put("Content-Type", contentType + "; charset=UTF-8");
-        }
-        else if (contentType.equalsIgnoreCase("text/plain")) {
-            response.headers.put("Content-Type", contentType + "; charset=UTF-8");
-        }
-        else if (contentType.equalsIgnoreCase("text/vtt")) {
-            response.headers.put("Content-Type", contentType + "; charset=UTF-8");
+        if (JSON_TYPE.equalsIgnoreCase(contentType) || TEXT_TYPE.equalsIgnoreCase(contentType) || VTT_TYPE.equalsIgnoreCase(contentType)) {
+            response.headers.put(CONTENT_TYPE_HEADER, contentType + "; charset=UTF-8");
         }
 
         return super.parseNetworkResponse(response);
@@ -99,7 +98,7 @@ public class VolleyStringRequest extends StringRequest {
 
         if (!tangible.DotNetToJavaStringHelper.isNullOrEmpty(request.getRequestContentType()))
         {
-            headers.put("Content-Type", request.getRequestContentType());
+            headers.put(CONTENT_TYPE_HEADER, request.getRequestContentType());
         }
 
         String parameter = requestHeaders.getAuthorizationParameter();
@@ -108,7 +107,7 @@ public class VolleyStringRequest extends StringRequest {
         {
             String value = requestHeaders.getAuthorizationScheme() + " " + parameter;
 
-            headers.put("X-Emby-Authorization", value);
+            headers.put(AUTHORIZATION_HEADER, value);
         }
     }
 

--- a/library/src/main/java/org/jellyfin/apiclient/interaction/ApiClient.java
+++ b/library/src/main/java/org/jellyfin/apiclient/interaction/ApiClient.java
@@ -117,7 +117,7 @@ public class ApiClient extends BaseApiClient {
 
             String errorCode = httpError.getHeaders().get("X-Application-Error-Code");
 
-            if (errorCode.equalsIgnoreCase("ParentalControl")) {
+            if ("ParentalControl".equalsIgnoreCase(errorCode)) {
                 reason = RemoteLogoutReason.ParentalControlRestriction;
             }
         }

--- a/library/src/main/java/org/jellyfin/apiclient/interaction/connectionmanager/ConnectionManager.java
+++ b/library/src/main/java/org/jellyfin/apiclient/interaction/connectionmanager/ConnectionManager.java
@@ -10,6 +10,7 @@ import org.jellyfin.apiclient.interaction.network.INetworkConnection;
 import org.jellyfin.apiclient.model.apiclient.*;
 import org.jellyfin.apiclient.model.dto.IHasServerId;
 import org.jellyfin.apiclient.model.dto.UserDto;
+import org.jellyfin.apiclient.model.extensions.StringHelper;
 import org.jellyfin.apiclient.model.logging.ILogger;
 import org.jellyfin.apiclient.model.serialization.IJsonSerializer;
 import org.jellyfin.apiclient.model.session.ClientCapabilities;
@@ -80,7 +81,7 @@ public class ConnectionManager implements IConnectionManager {
     public ServerInfo getServerInfo(String serverId) {
         final ServerCredentials credentials = credentialProvider.GetCredentials();
         for (ServerInfo server : credentials.getServers()) {
-            if (server.getId().equalsIgnoreCase(serverId)) {
+            if (StringHelper.equalsIgnoreCase(server.getId(), serverId)) {
                 return  server;
             }
         }
@@ -200,11 +201,11 @@ public class ConnectionManager implements IConnectionManager {
 
         else if (mode == ConnectionMode.Manual) {
 
-            if (address.equalsIgnoreCase(server.getLocalAddress())) {
+            if (StringHelper.equalsIgnoreCase(address, server.getLocalAddress())) {
                 logger.Debug("Skipping manual connection test because the address is the same as the local address");
                 skipTest = true;
             }
-            else if (address.equalsIgnoreCase(server.getRemoteAddress())) {
+            else if (StringHelper.equalsIgnoreCase(address, server.getRemoteAddress())) {
                 logger.Debug("Skipping manual connection test because the address is the same as the remote address");
                 skipTest = true;
             }
@@ -574,7 +575,7 @@ public class ConnectionManager implements IConnectionManager {
 
         ServerInfo server = null;
         for(ServerInfo current : existing) {
-            if (current.getId().equalsIgnoreCase(id)) {
+            if (StringHelper.equalsIgnoreCase(current.getId(), id)) {
                 server = current;
                 break;
             }
@@ -594,8 +595,7 @@ public class ConnectionManager implements IConnectionManager {
         ArrayList<ServerInfo> newList = new ArrayList<>();
 
         for(ServerInfo current : existing) {
-
-            if (!current.getId().equalsIgnoreCase(id)) {
+            if (!StringHelper.equalsIgnoreCase(current.getId(), id)) {
                 newList.add(current);
             }
         }

--- a/library/src/main/java/org/jellyfin/apiclient/interaction/websocket/ApiWebSocket.java
+++ b/library/src/main/java/org/jellyfin/apiclient/interaction/websocket/ApiWebSocket.java
@@ -139,109 +139,109 @@ public class ApiWebSocket implements ISocketListener {
 
         logger.Info("Received web socket message: %s", messageType);
 
-        if (messageType.equalsIgnoreCase("LibraryChanged"))
+        if ("LibraryChanged".equalsIgnoreCase(messageType))
         {
             LibraryUpdateInfo obj = jsonSerializer.DeserializeFromString(message, LibraryUpdateInfo.class);
             apiEventListener.onLibraryChanged(apiClient, obj);
 
         }
-        else if (messageType.equalsIgnoreCase("RestartRequired"))
+        else if ("RestartRequired".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("ServerRestarting"))
+        else if ("ServerRestarting".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("ServerShuttingDown"))
+        else if ("ServerShuttingDown".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("UserDeleted"))
+        else if ("UserDeleted".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("ScheduledTaskEnded"))
+        else if ("ScheduledTaskEnded".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("PackageInstalling"))
+        else if ("PackageInstalling".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("PackageInstallationFailed"))
+        else if ("PackageInstallationFailed".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("PackageInstallationCompleted"))
+        else if ("PackageInstallationCompleted".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("PackageInstallationCancelled"))
+        else if ("PackageInstallationCancelled".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("UserUpdated"))
+        else if ("UserUpdated".equalsIgnoreCase(messageType))
         {
             UserDtoMessage obj = jsonSerializer.DeserializeFromString(message, UserDtoMessage.class);
             apiEventListener.onUserUpdated(apiClient, obj.getData());
         }
-        else if (messageType.equalsIgnoreCase("UserConfigurationUpdated"))
+        else if ("UserConfigurationUpdated".equalsIgnoreCase(messageType))
         {
             UserDtoMessage obj = jsonSerializer.DeserializeFromString(message, UserDtoMessage.class);
             apiEventListener.onUserConfigurationUpdated(apiClient, obj.getData());
         }
-        else if (messageType.equalsIgnoreCase("PluginUninstalled"))
+        else if ("PluginUninstalled".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("Play"))
+        else if ("Play".equalsIgnoreCase(messageType))
         {
             PlayRequestMessage obj = jsonSerializer.DeserializeFromString(message, PlayRequestMessage.class);
             apiEventListener.onPlayCommand(apiClient, obj.getData());
         }
-        else if (messageType.equalsIgnoreCase("Playstate"))
+        else if ("Playstate".equalsIgnoreCase(messageType))
         {
             PlaystateRequestMessage obj = jsonSerializer.DeserializeFromString(message, PlaystateRequestMessage.class);
             apiEventListener.onPlaystateCommand(apiClient, obj.getData());
         }
-        else if (messageType.equalsIgnoreCase("NotificationAdded"))
+        else if ("NotificationAdded".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("NotificationUpdated"))
+        else if ("NotificationUpdated".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("NotificationsMarkedRead"))
+        else if ("NotificationsMarkedRead".equalsIgnoreCase(messageType))
         {
 
         }
-        else if (messageType.equalsIgnoreCase("GeneralCommand"))
+        else if ("GeneralCommand".equalsIgnoreCase(messageType))
         {
             OnGeneralCommand(message);
         }
-        else if (messageType.equalsIgnoreCase("Sessions"))
+        else if ("Sessions".equalsIgnoreCase(messageType))
         {
             SessionUpdatesEventMessage obj = jsonSerializer.DeserializeFromString(message, SessionUpdatesEventMessage.class);
             apiEventListener.onSessionsUpdated(apiClient, obj.getData());
         }
-        else if (messageType.equalsIgnoreCase("UserDataChanged"))
+        else if ("UserDataChanged".equalsIgnoreCase(messageType))
         {
             UserDataChangeMessage obj = jsonSerializer.DeserializeFromString(message, UserDataChangeMessage.class);
             apiEventListener.onUserDataChanged(apiClient, obj.getData());
         }
-        else if (messageType.equalsIgnoreCase("SessionEnded"))
+        else if ("SessionEnded".equalsIgnoreCase(messageType))
         {
             SessionInfoMessage obj = jsonSerializer.DeserializeFromString(message, SessionInfoMessage.class);
             apiEventListener.onSessionEnded(apiClient, obj.getData());
         }
-        else if (messageType.equalsIgnoreCase("PlaybackStart"))
+        else if ("PlaybackStart".equalsIgnoreCase(messageType))
         {
             SessionInfoMessage obj = jsonSerializer.DeserializeFromString(message, SessionInfoMessage.class);
             apiEventListener.onPlaybackStart(apiClient, obj.getData());
         }
-        else if (messageType.equalsIgnoreCase("PlaybackStopped"))
+        else if ("PlaybackStopped".equalsIgnoreCase(messageType))
         {
             SessionInfoMessage obj = jsonSerializer.DeserializeFromString(message, SessionInfoMessage.class);
             apiEventListener.onPlaybackStopped(apiClient, obj.getData());

--- a/library/src/main/java/org/jellyfin/apiclient/model/apiclient/ServerCredentials.java
+++ b/library/src/main/java/org/jellyfin/apiclient/model/apiclient/ServerCredentials.java
@@ -1,5 +1,7 @@
 package org.jellyfin.apiclient.model.apiclient;
 
+import org.jellyfin.apiclient.model.extensions.StringHelper;
+
 public class ServerCredentials
 {
 	private java.util.ArrayList<ServerInfo> Servers;
@@ -89,7 +91,7 @@ public class ServerCredentials
 
 		for (ServerInfo server : servers)
 		{
-			if (id.equalsIgnoreCase(server.getId()))
+			if (StringHelper.equalsIgnoreCase(id, server.getId()))
 			{
 				return index;
 			}
@@ -104,7 +106,7 @@ public class ServerCredentials
 	{
 		for (ServerInfo server : getServers())
 		{
-			if (id.equalsIgnoreCase(server.getId()))
+			if (StringHelper.equalsIgnoreCase(id, server.getId()))
 			{
 				return server;
 			}

--- a/library/src/main/java/org/jellyfin/apiclient/model/dlna/ConditionProcessor.java
+++ b/library/src/main/java/org/jellyfin/apiclient/model/dlna/ConditionProcessor.java
@@ -125,9 +125,9 @@ public class ConditionProcessor
 			case EqualsAny:
 				return ListHelper.ContainsIgnoreCase(expected.split("[|]", -1), currentValue);
 			case Equals:
-				return currentValue.equalsIgnoreCase(expected);
+				return StringHelper.equalsIgnoreCase(currentValue, expected);
 			case NotEquals:
-				return !currentValue.equalsIgnoreCase(expected);
+				return !StringHelper.equalsIgnoreCase(currentValue, expected);
 			default:
 				throw new IllegalStateException("Unexpected ProfileConditionType");
 		}

--- a/library/src/main/java/org/jellyfin/apiclient/model/dlna/DeviceProfile.java
+++ b/library/src/main/java/org/jellyfin/apiclient/model/dlna/DeviceProfile.java
@@ -517,7 +517,7 @@ public class DeviceProfile
 			}
 
 			String tempVar = i.getVideoCodec();
-			if (!videoCodec.equalsIgnoreCase((tempVar != null) ? tempVar : ""))
+			if (!StringHelper.equalsIgnoreCase(videoCodec, (tempVar != null) ? tempVar : ""))
 			{
 				continue;
 			}

--- a/library/src/main/java/org/jellyfin/apiclient/model/dto/BaseItemDto.java
+++ b/library/src/main/java/org/jellyfin/apiclient/model/dto/BaseItemDto.java
@@ -1689,7 +1689,7 @@ public class BaseItemDto implements IHasProviderIds, IHasServerId
 	*/
 	public final boolean IsType(String type)
 	{
-		return getType().equalsIgnoreCase(type);
+		return StringHelper.equalsIgnoreCase(getType(), type);
 	}
 
 	/**
@@ -2483,7 +2483,7 @@ public class BaseItemDto implements IHasProviderIds, IHasServerId
 	*/
 	public final boolean getIsVideo()
 	{
-		return getMediaType().equalsIgnoreCase(org.jellyfin.apiclient.model.entities.MediaType.Video);
+		return org.jellyfin.apiclient.model.entities.MediaType.Video.equalsIgnoreCase(getMediaType());
 	}
 
 	/**
@@ -2493,7 +2493,7 @@ public class BaseItemDto implements IHasProviderIds, IHasServerId
 	*/
 	public final boolean getIsAudio()
 	{
-		return getMediaType().equalsIgnoreCase(org.jellyfin.apiclient.model.entities.MediaType.Audio);
+		return org.jellyfin.apiclient.model.entities.MediaType.Audio.equalsIgnoreCase(getMediaType());
 	}
 
 	/**
@@ -2503,7 +2503,7 @@ public class BaseItemDto implements IHasProviderIds, IHasServerId
 	*/
 	public final boolean getIsGame()
 	{
-		return getMediaType().equalsIgnoreCase(org.jellyfin.apiclient.model.entities.MediaType.Game);
+		return org.jellyfin.apiclient.model.entities.MediaType.Game.equalsIgnoreCase(getMediaType());
 	}
 
 	/**
@@ -2513,7 +2513,7 @@ public class BaseItemDto implements IHasProviderIds, IHasServerId
 	*/
 	public final boolean getIsPerson()
 	{
-		return getType().equalsIgnoreCase("Person");
+		return "Person".equalsIgnoreCase(getType());
 	}
 
 	/**
@@ -2523,37 +2523,37 @@ public class BaseItemDto implements IHasProviderIds, IHasServerId
 	*/
 	public final boolean getIsRoot()
 	{
-		return getType().equalsIgnoreCase("AggregateFolder");
+		return "AggregateFolder".equalsIgnoreCase(getType());
 	}
 
 	public final boolean getIsMusicGenre()
 	{
-		return getType().equalsIgnoreCase("MusicGenre");
+		return "MusicGenre".equalsIgnoreCase(getType());
 	}
 
 	public final boolean getIsGameGenre()
 	{
-		return getType().equalsIgnoreCase("GameGenre");
+		return "GameGenre".equalsIgnoreCase(getType());
 	}
 
 	public final boolean getIsGenre()
 	{
-		return getType().equalsIgnoreCase("Genre");
+		return "Genre".equalsIgnoreCase(getType());
 	}
 
 	public final boolean getIsArtist()
 	{
-		return getType().equalsIgnoreCase("MusicArtist");
+		return "MusicArtist".equalsIgnoreCase(getType());
 	}
 
 	public final boolean getIsAlbum()
 	{
-		return getType().equalsIgnoreCase("MusicAlbum");
+		return "MusicAlbum".equalsIgnoreCase(getType());
 	}
 
 	public final boolean getIsStudio()
 	{
-		return getType().equalsIgnoreCase("Studio");
+		return "Studio".equalsIgnoreCase(getType());
 	}
 
 	public final boolean getSupportsSimilarItems()

--- a/library/src/main/java/org/jellyfin/apiclient/model/entities/MediaStream.java
+++ b/library/src/main/java/org/jellyfin/apiclient/model/entities/MediaStream.java
@@ -494,7 +494,7 @@ public class MediaStream
 		// sub indicates an external .sub file
 		Pattern compatible = Pattern.compile(".*[pgs|dvd|dvbsub].*]", Pattern.CASE_INSENSITIVE);
 		Matcher matcher = compatible.matcher(codec);
-		return !matcher.matches() && !codec.equalsIgnoreCase("sub");
+		return !matcher.matches() && !"sub".equalsIgnoreCase(codec);
 	}
 
 	public final boolean SupportsSubtitleConversionTo(String codec)
@@ -505,26 +505,7 @@ public class MediaStream
 		}
 
 		// Can't convert from this 
-		if (getCodec().equalsIgnoreCase("ass"))
-		{
-			return false;
-		}
-		if (getCodec().equalsIgnoreCase("ssa"))
-		{
-			return false;
-		}
-
-		// Can't convert to this 
-		if (codec.equalsIgnoreCase("ass"))
-		{
-			return false;
-		}
-		if (codec.equalsIgnoreCase("ssa"))
-		{
-			return false;
-		}
-
-		return true;
+		return !("ass".equalsIgnoreCase(getCodec()) || "ssa".equalsIgnoreCase(getCodec()) || "ass".equalsIgnoreCase(codec) || "ssa".equalsIgnoreCase(codec));
 	}
 
 	/** 

--- a/library/src/main/java/org/jellyfin/apiclient/model/extensions/StringHelper.java
+++ b/library/src/main/java/org/jellyfin/apiclient/model/extensions/StringHelper.java
@@ -1,0 +1,22 @@
+package org.jellyfin.apiclient.model.extensions;
+
+/**
+ Isolating these helpers allow this entire project to be easily converted to Java
+ */
+public final class StringHelper
+{
+    /**
+     Null safe {@code equalsIgnoreCase}.
+
+     @param str1 The first String.
+     @param str2 The second String.
+     @return <c>true</c> if both strings are null or equalsIgnoreCase, <c>false</c> otherwise.
+     */
+    public static boolean equalsIgnoreCase(String str1, String str2) {
+        if (str1 == null && str2 == null) return true;
+
+        if (str1 == null || str2 == null) return false;
+
+        return str1.equalsIgnoreCase(str2);
+    }
+}


### PR DESCRIPTION
Restores the `null` safe `equalsIgnoreCase` helper and changes the order of some native `equalsIgnoreCase` parameters to avoid `NullPointerException`s.