### PR TITLE
Use ApiClient methods for url generation

### DIFF
--- a/library/src/main/java/org/jellyfin/apiclient/interaction/BaseApiClient.java
+++ b/library/src/main/java/org/jellyfin/apiclient/interaction/BaseApiClient.java
@@ -1120,7 +1120,7 @@ public abstract class BaseApiClient
 	 @param url The URL.
 	 @return System.String.
 	*/
-	protected final String AddDataFormat(String url)
+	public final String AddDataFormat(String url)
 	{
         if (url == null)
         {


### PR DESCRIPTION
This addresses the issue in https://github.com/jellyfin/jellyfin-androidtv/issues/155 where the initial user lookup uses the old "mediabrowser" api endpoint.