### PR TITLE
Delete Game and GameGenre ItemTypes

### DIFF
--- a/library/src/main/java/org/jellyfin/apiclient/model/dto/BaseItemDto.java
+++ b/library/src/main/java/org/jellyfin/apiclient/model/dto/BaseItemDto.java
@@ -2522,11 +2522,6 @@ public class BaseItemDto implements IHasProviderIds, IHasServerId
 		return getBaseItemType() == BaseItemType.MusicGenre;
 	}
 
-	public final boolean getIsGameGenre()
-	{
-		return getBaseItemType() == BaseItemType.GameGenre;
-	}
-
 	public final boolean getIsGenre()
 	{
 		return getBaseItemType() == BaseItemType.Genre;
@@ -2555,8 +2550,7 @@ public class BaseItemDto implements IHasProviderIds, IHasServerId
 				|| getBaseItemType() == BaseItemType.MusicArtist
 				|| getBaseItemType() == BaseItemType.Program
 				|| getBaseItemType() == BaseItemType.Recording
-				|| getBaseItemType() == BaseItemType.ChannelVideoItem
-				|| getBaseItemType() == BaseItemType.Game;
+				|| getBaseItemType() == BaseItemType.ChannelVideoItem;
 	}
 
 	/** 

--- a/library/src/main/java/org/jellyfin/apiclient/model/dto/BaseItemType.java
+++ b/library/src/main/java/org/jellyfin/apiclient/model/dto/BaseItemType.java
@@ -10,8 +10,6 @@ public enum BaseItemType {
     CollectionFolder,
     Episode,
     Folder,
-    Game,
-    GameGenre,
     Genre,
     LiveTvChannel,
     Movie,


### PR DESCRIPTION
The Server does not support them anymore, so I am removing the `Game` and `GameGenre` `BaseItemType`s. There's still more game related stuff in the `BaseItemDto`, which could also be deleted, but since this will be deprecated at some point anyway, I don't care enough to do it.