### PR TITLE
Update Java-WebSocket to 1.4.0 and some misc fixes

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 dependencies {
-    implementation 'org.java-websocket:Java-WebSocket:1.3.0'
+    implementation 'org.java-websocket:Java-WebSocket:1.4.0'
     implementation 'com.google.code.gson:gson:2.8.2'
     testImplementation 'junit:junit:4.12'
 }

--- a/library/src/main/java/org/jellyfin/apiclient/interaction/websocket/ApiWebSocket.java
+++ b/library/src/main/java/org/jellyfin/apiclient/interaction/websocket/ApiWebSocket.java
@@ -8,7 +8,9 @@ import org.jellyfin.apiclient.model.entities.LibraryUpdateInfo;
 import org.jellyfin.apiclient.model.logging.ILogger;
 import org.jellyfin.apiclient.model.net.WebSocketMessage;
 import org.jellyfin.apiclient.model.serialization.IJsonSerializer;
-import org.jellyfin.apiclient.model.session.*;
+import org.jellyfin.apiclient.model.session.BrowseRequest;
+import org.jellyfin.apiclient.model.session.GeneralCommandType;
+import org.jellyfin.apiclient.model.session.MessageCommand;
 
 import java.net.URI;
 import java.net.URLEncoder;
@@ -57,8 +59,7 @@ public class ApiWebSocket implements ISocketListener {
     }
 
     private String getWebSocketServerAddress() {
-
-        return apiClient.getApiUrl().replace("http", "ws") + "/embywebsocket?api_key=" + apiClient.getAccessToken() + "&deviceId=" + URLEncoder.encode(apiClient.getDeviceId());
+        return apiClient.getApiUrl().replaceFirst("^http", "ws") + "/socket?api_key=" + apiClient.getAccessToken() + "&deviceId=" + URLEncoder.encode(apiClient.getDeviceId());
     }
 
     public void CloseWebSocket() {

--- a/library/src/main/java/org/jellyfin/apiclient/interaction/websocket/JavaWebSocketClient.java
+++ b/library/src/main/java/org/jellyfin/apiclient/interaction/websocket/JavaWebSocketClient.java
@@ -1,9 +1,9 @@
 package org.jellyfin.apiclient.interaction.websocket;
 
-import org.jellyfin.apiclient.model.logging.ILogger;
-import org.java_websocket.WebSocket;
 import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.enums.ReadyState;
 import org.java_websocket.handshake.ServerHandshake;
+import org.jellyfin.apiclient.model.logging.ILogger;
 
 import java.net.URI;
 
@@ -33,9 +33,8 @@ public class JavaWebSocketClient extends WebSocketClient {
     }
 
     @Override
-    public void onClose(int i, String s, boolean b) {
-
-        _logger.Info("Web socket connection closed.");
+    public void onClose(int i, String reason, boolean b) {
+        _logger.Info("Web socket connection closed. Reason: " + reason);
         listener.onClose();
     }
 
@@ -47,15 +46,15 @@ public class JavaWebSocketClient extends WebSocketClient {
 
     public boolean IsWebSocketOpen() {
 
-        WebSocket.READYSTATE state = getReadyState();
+        ReadyState state = getReadyState();
 
-        return  state == WebSocket.READYSTATE.OPEN;
+        return state == ReadyState.OPEN;
     }
 
     public boolean IsWebSocketOpenOrConnecting() {
 
-        WebSocket.READYSTATE state = getReadyState();
+        ReadyState state = getReadyState();
 
-        return  state == WebSocket.READYSTATE.OPEN || state == WebSocket.READYSTATE.CONNECTING;
+        return state == ReadyState.OPEN || state == ReadyState.NOT_YET_CONNECTED;
     }
 }


### PR DESCRIPTION
Looking at the logs the app showed me it tried to connect but the connection would close within a few sec. I noticed the path was set to `/embysocket` but web connects to `/socket` so I changed that.
It still didn't work... What could happen? Hmm looking at the code I noticed the `onClose` method gets 3 parameters: `int i, String s, boolean b` but they aren't logged.. Let's log them!

The error was in string s and said: `draft org.java_websocket.drafts.Draft_10@236b291 refuses handshake`.. Well.. What's draft 10? It's an old version of the websocket spec! Can we upgrade it? Our library supports setting the draft as parameter in the constructor so I set it to the latest version available, this was 76.. Still didn't work :(
Looking at Wikipedia I saw there's a newer version for the protocol so let's look at the library version... We use 1.3.0 and the latest version is 1.4.0. I tried upgrading but breaking changes, hmm lets try a slightly older version first for testing. I changed it to 1.3.4 as it introduced Draft_6455 and deprecated all the other ones..

I compiled this and.. well... it worked!

I proceeded to upgrade to the latest version and added an additional fix when determining the websocket url.

Example how it would look in the webclient when this fix is applied in Android TV:
![image](https://user-images.githubusercontent.com/2305178/74687483-c5b34c00-51d4-11ea-9bce-60572d91ea8f.png)
