### PR TITLE
Publish to Bintray

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
 	id("com.android.library")
-	id("com.github.dcendents.android-maven")
 
 	id("kotlin-android")
 	id("kotlin-android-extensions")

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -38,12 +38,8 @@ dependencies {
 // Because of limitations in the android plugin
 // the publishing definition should be inside the "afterEvaluate" block
 afterEvaluate {
-	publishing {
-		publications {
-			create<MavenPublication>("maven") {
-				// Should be the same as the build type
-				from(components["release"])
-			}
-		}
+	publishing.publications.create<MavenPublication>("maven") {
+		// Should be the same as the build type
+		from(components["release"])
 	}
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -34,3 +34,16 @@ dependencies {
 
 	implementation("com.android.volley:volley:1.1.1")
 }
+
+// Because of limitations in the android plugin
+// the publishing definition should be inside the "afterEvaluate" block
+afterEvaluate {
+	publishing {
+		publications {
+			create<MavenPublication>("maven") {
+				// Should be the same as the build type
+				from(components["release"])
+			}
+		}
+	}
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 // Because of limitations in the android plugin
 // the publishing definition should be inside the "afterEvaluate" block
 afterEvaluate {
-	publishing.publications.create<MavenPublication>("maven") {
+	publishing.publications.create<MavenPublication>("default") {
 		// Should be the same as the build type
 		from(components["release"])
 	}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,6 @@ buildscript {
 	dependencies {
 		classpath("com.android.tools.build:gradle:3.6.3")
 		classpath(kotlin("gradle-plugin", "1.3.72"))
-		classpath("com.github.dcendents:android-maven-gradle-plugin:2.1")
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,8 @@ allprojects {
 	}
 
 	publishing.repositories.maven {
-		url = uri("https://api.bintray.com/maven/nielsvanvelzen/jellyfin-apiclient-java/jellyfin-apiclient-java/;publish=0")
+		name = "bintray"
+		url = uri("https://api.bintray.com/maven/nielsvanvelzen/jellyfin-apiclient-java/jellyfin-apiclient-java;publish=0;override=1")
 
 		credentials {
 			username = getProperty("bintray.user") as String?

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ allprojects {
 
 	publishing.repositories.maven {
 		name = "bintray"
-		url = uri("https://api.bintray.com/maven/nielsvanvelzen/jellyfin-apiclient-java/jellyfin-apiclient-java;publish=0;override=1")
+		url = uri("https://bintray.com/jellyfin/jellyfin-apiclient-java/jellyfin-apiclient-java;publish=1;override=1")
 
 		credentials {
 			username = getProperty("bintray.user") as String?

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,13 @@
+plugins {
+	id("maven-publish")
+}
+
+// Versioning
+allprojects {
+	group = "org.jellyfin.apiclient"
+	version = getProperty("jellyfin.version") ?: "SNAPSHOT"
+}
+
 buildscript {
 	repositories {
 		google()
@@ -11,8 +21,33 @@ buildscript {
 }
 
 allprojects {
+	apply(plugin = "maven-publish")
+
 	repositories {
 		google()
 		jcenter()
 	}
+
+	publishing {
+		repositories {
+			maven {
+				url = uri("https://api.bintray.com/maven/nielsvanvelzen/jellyfin-apiclient-java/jellyfin-apiclient-java/;publish=0")
+
+				credentials {
+					username = getProperty("bintray.user") as String?
+					password = getProperty("bintray.key") as String?
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Helper function to retrieve configuration variable values
+ */
+fun getProperty(name: String): Any? {
+	// sample.var --> SAMPLE_VAR
+	val environmentName = name.toUpperCase().replace(".", "_")
+
+	return project.findProperty(name) ?: System.getenv(environmentName) ?: null
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,16 +28,12 @@ allprojects {
 		jcenter()
 	}
 
-	publishing {
-		repositories {
-			maven {
-				url = uri("https://api.bintray.com/maven/nielsvanvelzen/jellyfin-apiclient-java/jellyfin-apiclient-java/;publish=0")
+	publishing.repositories.maven {
+		url = uri("https://api.bintray.com/maven/nielsvanvelzen/jellyfin-apiclient-java/jellyfin-apiclient-java/;publish=0")
 
-				credentials {
-					username = getProperty("bintray.user") as String?
-					password = getProperty("bintray.key") as String?
-				}
-			}
+		credentials {
+			username = getProperty("bintray.user") as String?
+			password = getProperty("bintray.key") as String?
 		}
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 android.useAndroidX=true
+kotlin.incremental=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,7 @@
 android.useAndroidX=true
 kotlin.incremental=true
+
+# When publishing the "secure" checksums Bintray is unable to correctly identify the versions
+# and will use the artifact names (modules) as version names
+# See https://github.com/gradle/gradle/issues/11412
+systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -17,7 +17,7 @@ val sourcesJar by tasks.creating(Jar::class) {
 	from(sourceSets.getByName("main").allSource)
 }
 
-publishing.publications.create<MavenPublication>("maven") {
+publishing.publications.create<MavenPublication>("default") {
 	from(components["java"])
 
 	artifact(sourcesJar)

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -17,12 +17,8 @@ val sourcesJar by tasks.creating(Jar::class) {
 	from(sourceSets.getByName("main").allSource)
 }
 
-publishing {
-	publications {
-		create<MavenPublication>("maven") {
-			from(components["java"])
+publishing.publications.create<MavenPublication>("maven") {
+	from(components["java"])
 
-			artifact(sourcesJar)
-		}
-	}
+	artifact(sourcesJar)
 }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -10,3 +10,19 @@ dependencies {
 
 	testImplementation("junit:junit:4.12")
 }
+
+val sourcesJar by tasks.creating(Jar::class) {
+	archiveClassifier.set("sources")
+
+	from(sourceSets.getByName("main").allSource)
+}
+
+publishing {
+	publications {
+		create<MavenPublication>("maven") {
+			from(components["java"])
+
+			artifact(sourcesJar)
+		}
+	}
+}

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
 	id("java-library")
-	id("maven")
 }
 
 dependencies {
@@ -8,5 +7,6 @@ dependencies {
 
 	implementation("org.java-websocket:Java-WebSocket:1.4.1")
 	implementation("com.google.code.gson:gson:2.8.6")
+
 	testImplementation("junit:junit:4.12")
 }

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -9,7 +9,7 @@ val sourcesJar by tasks.creating(Jar::class) {
 	from(sourceSets.getByName("main").allSource)
 }
 
-publishing.publications.create<MavenPublication>("maven") {
+publishing.publications.create<MavenPublication>("default") {
 	from(components["java"])
 
 	artifact(sourcesJar)

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	id("java-library")
+	id("maven-publish")
 }
 
 val sourcesJar by tasks.creating(Jar::class) {
@@ -8,12 +9,8 @@ val sourcesJar by tasks.creating(Jar::class) {
 	from(sourceSets.getByName("main").allSource)
 }
 
-publishing {
-	publications {
-		create<MavenPublication>("maven") {
-			from(components["java"])
+publishing.publications.create<MavenPublication>("maven") {
+	from(components["java"])
 
-			artifact(sourcesJar)
-		}
-	}
+	artifact(sourcesJar)
 }

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -1,3 +1,19 @@
 plugins {
 	id("java-library")
 }
+
+val sourcesJar by tasks.creating(Jar::class) {
+	archiveClassifier.set("sources")
+
+	from(sourceSets.getByName("main").allSource)
+}
+
+publishing {
+	publications {
+		create<MavenPublication>("maven") {
+			from(components["java"])
+
+			artifact(sourcesJar)
+		}
+	}
+}

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -1,8 +1,3 @@
 plugins {
 	id("java-library")
-	id("maven")
-}
-
-dependencies {
-
 }


### PR DESCRIPTION
This PR will fix #2 and add support for deployment to Bintray! It's not automated yet, that will be done in a future PR.

**How to use**
Three environment variables should be used:
- `BINTRAY_USER` should be set to the deployment user
- `BINTRAY_KEY` should be set to the deployment key
- `JELLYFIN_VERSION` is optional and will fallback to "SNAPSHOT" but should normally be the same as the git tag

During development I used my own account to deploy to, a sample which deployed this branch as 0.0.1 can be found here: https://bintray.com/nielsvanvelzen/jellyfin-apiclient-java/jellyfin-apiclient-java.

Closes #2