### PR TITLE
Enable Kotlin support for all modules

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,9 +1,11 @@
 plugins {
-	id("java-library")
+	id("kotlin")
 }
 
 dependencies {
 	api(project(":model"))
+
+	implementation(kotlin("stdlib-jdk7"))
 
 	implementation("org.java-websocket:Java-WebSocket:1.4.1")
 	implementation("com.google.code.gson:gson:2.8.6")

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
-	id("java-library")
-	id("maven-publish")
+	id("kotlin")
 }
 
 val sourcesJar by tasks.creating(Jar::class) {


### PR DESCRIPTION
This is a simple one that will be needed for future changes, all modules now support Kotlin. I also fixed a small mistake in the model build.gradle.kts defining the maven plugin a second time