### PR TITLE
Add support for SearchTerm on ItemByNameQueries

### DIFF
--- a/library/src/main/java/org/jellyfin/apiclient/interaction/BaseApiClient.java
+++ b/library/src/main/java/org/jellyfin/apiclient/interaction/BaseApiClient.java
@@ -625,6 +625,7 @@ public abstract class BaseApiClient
 		dict.AddIfNotNullOrEmpty("NameLessThan", query.getNameLessThan());
 		dict.AddIfNotNullOrEmpty("NameStartsWith", query.getNameStartsWith());
 		dict.AddIfNotNullOrEmpty("NameStartsWithOrGreater", query.getNameStartsWithOrGreater());
+		dict.AddIfNotNullOrEmpty("SearchTerm", query.getSearchTerm());
 
         dict.AddIfNotNull("EnableImages", query.getEnableImages());
         dict.AddIfNotNull("ImageTypeLimit", query.getImageTypeLimit());

--- a/model/src/main/java/org/jellyfin/apiclient/model/querying/ItemsByNameQuery.java
+++ b/model/src/main/java/org/jellyfin/apiclient/model/querying/ItemsByNameQuery.java
@@ -240,6 +240,20 @@ public class ItemsByNameQuery
 		NameLessThan = value;
 	}
 
+	/**
+	 Search characters used to find items
+	 <value>The index by.</value>
+	 */
+	private String SearchTerm;
+	public final String getSearchTerm()
+	{
+		return SearchTerm;
+	}
+	public final void setSearchTerm(String value)
+	{
+		SearchTerm = value;
+	}
+
 	/** 
 	 Gets or sets a value indicating whether this instance is played.
 	 


### PR DESCRIPTION
Add support for SearchTerm on by-name API queries.
See [backend](https://github.com/jellyfin/jellyfin/blob/18953d95e6692290bf56547d4c9614790687654c/MediaBrowser.Api/UserLibrary/BaseItemsByNameService.cs#L136).