### PR TITLE
Fix discovery duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@
 <a href="https://github.com/jellyfin/jellyfin-apiclient-java/releases">
 <img alt="Current Release" src="https://img.shields.io/github/release/jellyfin/jellyfin-apiclient-java.svg"/>
 </a>
-<a href="https://dev.azure.com/jellyfin-project/jellyfin/_build/latest?definitionId=6&branchName=master">
-<img alt="Azure DevOps builds" src="https://dev.azure.com/jellyfin-project/jellyfin/_apis/build/status/Jellyfin%20API%20Client%20Java%20CI?branchName=master">
-</a>
 <br/>
 <a href="https://opencollective.com/jellyfin">
 <img alt="Donate" src="https://img.shields.io/opencollective/all/jellyfin.svg?label=backers"/>
@@ -42,11 +39,13 @@
 
 ---
 
-This library allows Java and Android applications to easily access the Jellyfin API. It is built with Volley, OkHttp, Boon, and Robolectric. The dependencies are modular and can easily be swapped out with alternate implementations when desired.
+This library allows Java and Android applications to easily access Jellyfin servers.
+The dependencies are modular and can easily be swapped out with alternate implementations when desired.
 
 ## Android Example
 
-This is an example of connecting to a single server using a fixed address from an Android app that has requires a user login.
+This Kotlin example creates a new instance of the Jellyfin class with Android support enabled.
+It will then try to authenticate to a server with a username and password combination.
 
 ```kotlin
 // Create a Jellyfin instance
@@ -74,9 +73,9 @@ apiClient.AuthenticateUserAsync("username", "password", object : Response<Authen
 })
 ```
 
-## Web Socket
+## Websockets
 
-Once you have an ApiClient instance you can easily connect to the server's web socket using the following command.
+Once you have an ApiClient instance you can easily connect to the server's websocket using the following command.
 
 ```kotlin
 apiClient.OpenWebSocket()
@@ -91,7 +90,7 @@ override fun onSetVolumeCommand(value: Int) {
 
 ## Using Java
 
-The Jellyfin library supports both Java and Kotlin out of the box. The basic Android example in Java looks like this
+The Jellyfin library supports both Java and Kotlin out of the box. The basic Android example in Java looks like this:
 
 ```java
 // Create the options using the options builder

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
 	}
 
 	dependencies {
-		classpath("com.android.tools.build:gradle:3.6.3")
+		classpath("com.android.tools.build:gradle:4.0.1")
 		classpath(kotlin("gradle-plugin", "1.3.72"))
 	}
 }

--- a/library/src/main/java/org/jellyfin/apiclient/discovery/ServerDiscovery.kt
+++ b/library/src/main/java/org/jellyfin/apiclient/discovery/ServerDiscovery.kt
@@ -96,10 +96,16 @@ class ServerDiscovery(
 		logger.debug("Discovery: Finished sending broadcasts, listening for responses")
 
 		// Try reading incoming messages but with a maximum
+		val foundServers = mutableSetOf<String>()
 		for (i in 0..maxServers) {
 			if (socket.isClosed || !GlobalScope.isActive) break
 
 			val info = receive(socket) ?: continue
+
+			// Filter duplicates
+			if (info.id in foundServers) continue
+			foundServers += info.id
+
 			emit(info)
 		}
 

--- a/samples/kotlin-console/src/main/kotlin/org/jellyfin/sample/console/Main.kt
+++ b/samples/kotlin-console/src/main/kotlin/org/jellyfin/sample/console/Main.kt
@@ -26,8 +26,5 @@ fun main(args: Array<String>) {
 		subcommands(Libraries(jellyfin, device))
 
 		parse(args)
-//		parse(arrayOf("discover"))
-//		parse("login --server https://demo.jellyfin.org/stable --username demo --password ".split(" ").toTypedArray())
-//		parse("libraries --server https://demo.jellyfin.org/stable --token 1d1e113ab39e4804bb42580b4323810b".split(" ").toTypedArray())
 	}
 }

--- a/samples/kotlin-console/src/main/kotlin/org/jellyfin/sample/console/cli/Libraries.kt
+++ b/samples/kotlin-console/src/main/kotlin/org/jellyfin/sample/console/cli/Libraries.kt
@@ -14,8 +14,8 @@ class Libraries(
 	private val jellyfin: Jellyfin,
 	private val device: IDevice
 ) : Subcommand("libraries", "List all libraries") {
-	val server by option(ArgType.String, description = "Url of the server", shortName = "s").required()
-	val token by option(ArgType.String, description = "Access token", shortName = "t").required()
+	private val server by option(ArgType.String, description = "Url of the server", shortName = "s").required()
+	private val token by option(ArgType.String, description = "Access token", shortName = "t").required()
 
 	override fun execute() = runBlocking {
 		val api = jellyfin.createApi(serverAddress = server, accessToken = token, device = device)

--- a/samples/kotlin-console/src/main/kotlin/org/jellyfin/sample/console/cli/Login.kt
+++ b/samples/kotlin-console/src/main/kotlin/org/jellyfin/sample/console/cli/Login.kt
@@ -13,9 +13,9 @@ class Login(
 	private val jellyfin: Jellyfin,
 	private val device: IDevice
 ) : Subcommand("login", "Login to a given server and retrieve an access token") {
-	val server by option(ArgType.String, description = "Url of the server", shortName = "s").required()
-	val username by option(ArgType.String, description = "Username", shortName = "u").required()
-	val password by option(ArgType.String, description = "Password", shortName = "p")
+	private val server by option(ArgType.String, description = "Url of the server", shortName = "s").required()
+	private val username by option(ArgType.String, description = "Username", shortName = "u").required()
+	private val password by option(ArgType.String, description = "Password", shortName = "p")
 
 	override fun execute() = runBlocking {
 		val api = jellyfin.createApi(serverAddress = server, device = device)


### PR DESCRIPTION
Fixed server discovery sometimes emitting the same server multiple times. It will now prevent this by remembering server ids.

Also fixed some miscellaneous issues:
- Removed Azure pipeline badge from README as it didn't work and the status can be seen per commit anyway
- Some grammar, spelling and rephrasing changes in README
- Removed some debug code comments from the CLI sample
- Made CLI sample arguments private
- Updated Gradle plugin version