### PR TITLE
Rewrite Azure pipeline based on ATV app pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,4 +81,4 @@ jobs:
           assets: '**/libs/*.jar'
           action: 'edit'
           assetUploadMode: 'replace'
-          tag: '$(TAG)'
+          tag: '$(JELLYFIN_VERSION)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,15 +1,84 @@
+variables:
+  - group: 'jellyfin'
+
 trigger:
-- master
+  batch: true
+  branches:
+    include:
+      - master
+      - release*
+  tags:
+    include:
+      - '*'
 
-pool:
-  vmImage: 'ubuntu-latest'
+pr:
+  branches:
+    include:
+      - '*'
 
-steps:
-- task: Gradle@2
-  inputs:
-    gradleWrapperFile: 'gradlew'
-    tasks: 'build'
-    publishJUnitResults: true
-    testResultsFiles: '**/TEST-*.xml'
-    javaHomeOption: 'JDKVersion'
-    sonarQubeRunAnalysis: false
+jobs:
+  - job: Test
+    displayName: 'Test'
+
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    steps:
+      - task: Gradle@2
+        displayName: 'Run Tests'
+        inputs:
+          gradleWrapperFile: 'gradlew'
+          tasks: 'test'
+          publishJUnitResults: true
+          testResultsFiles: '**/TEST-*.xml'
+          javaHomeOption: 'JDKVersion'
+          sonarQubeRunAnalysis: false
+
+  - job: Build
+    displayName: 'Build'
+
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    steps:
+      - task: Gradle@2
+        displayName: 'Build'
+        inputs:
+          gradleWrapperFile: 'gradlew'
+          tasks: 'distZip'
+          publishJUnitResults: false
+          testResultsFiles: '**/TEST-*.xml'
+          javaHomeOption: 'JDKVersion'
+          sonarQubeRunAnalysis: false
+
+  - job: Publish
+    displayName: 'Publish'
+
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    steps:
+      - script: 'echo "##vso[task.setvariable variable=JELLYFIN_VERSION]$(git describe --tags)"'
+        displayName: 'Set Version Variable'
+
+      - task: Gradle@2
+        displayName: 'Build & Publish'
+        inputs:
+          gradleWrapperFile: 'gradlew'
+          tasks: 'publish'
+          publishJUnitResults: false
+          testResultsFiles: '**/TEST-*.xml'
+          javaHomeOption: 'JDKVersion'
+          sonarQubeRunAnalysis: false
+
+      - task: GithubRelease@0
+        displayName: 'GitHub Upload'
+        inputs:
+          gitHubConnection: Jellyfin Release Download
+          repositoryName: jellyfin/jellyfin-apiclient-java
+          assets: '**/libs/*.jar'
+          action: 'edit'
+          assetUploadMode: 'replace'
+          tag: '$(TAG)'


### PR DESCRIPTION
# ⭐  Everything in this PR is untested! 🚀 🌟 

What this should do:
- Build master and PR's
- Test master and PR's
- Upload .jar files to GitHub releases (including source jars)
- Publish library to [Bintray](https://bintray.com/jellyfin/jellyfin-apiclient-java/jellyfin-apiclient-java)
- Set version of the library based on the git tag

What needs to be done by someone with access to Azure:
- Add 2 environment variables called `BINTRAY_USER` and `BINTRAY_KEY` with credentials for the publisher. We should probably create a bot account for that.

If everything is ready and checked by living humans with more Azure pipeline knowledge than me we could theoretically release 0.7.0.

---

See #54 for the Bintray PR

---

This PR closes #59 