### PR TITLE
Generate Android version code

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,6 +5,33 @@ plugins {
 	id("kotlin-android-extensions")
 }
 
+/**
+ * Get the versioncode for a given semver. Returns null if value is invalid.
+ *
+ * Sample output:
+ * 0.0.0 -> 0
+ * 1.1.1 -> 10101
+ * 0.7.0 -> 700
+ * 99.99.99 -> 999999
+ */
+fun getVersionCode(semver: String): Int? {
+	val parts = semver.splitToSequence('.')
+		.take(3)
+		.map { it.toIntOrNull() }
+		.filterNotNull()
+		.toList()
+
+	// Not a valid semver
+	if (parts.size != 3) return null
+
+	var code = 0
+	code += parts[0] * 10000 // Major (0-99)
+	code += parts[1] * 100 // Minor (0-99)
+	code += parts[2] // Patch (0-99)
+
+	return code
+}
+
 android {
 	compileSdkVersion(29)
 
@@ -12,8 +39,8 @@ android {
 		minSdkVersion(19)
 		targetSdkVersion(29)
 
-		versionCode = 27
-		versionName = "0.6.0"
+		versionCode = getVersionCode(project.version.toString()) ?: 0
+		versionName = project.version.toString()
 	}
 
 	compileOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 // Versioning
 allprojects {
 	group = "org.jellyfin.apiclient"
-	version = getProperty("jellyfin.version") ?: "SNAPSHOT"
+	version = getProperty("jellyfin.version")?.removePrefix("v") ?: "SNAPSHOT"
 }
 
 buildscript {
@@ -51,9 +51,9 @@ allprojects {
 /**
  * Helper function to retrieve configuration variable values
  */
-fun getProperty(name: String): Any? {
+fun getProperty(name: String): String? {
 	// sample.var --> SAMPLE_VAR
 	val environmentName = name.toUpperCase().replace(".", "_")
 
-	return project.findProperty(name) ?: System.getenv(environmentName) ?: null
+	return project.findProperty(name)?.toString() ?: System.getenv(environmentName) ?: null
 }


### PR DESCRIPTION
This PR will automatically set the Android version name and code based on the "jellyfin.version" property. This means that based on #78 when releasing the git tag is the version used for the build. No need to commit a version change anymore.