### PR TITLE
Add buildSrc gradle project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.iml
 /.idea
 
-/.gradle
+.gradle
 local.properties
 
 build/

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,33 +5,6 @@ plugins {
 	id("kotlin-android-extensions")
 }
 
-/**
- * Get the versioncode for a given semver. Returns null if value is invalid.
- *
- * Sample output:
- * 0.0.0 -> 0
- * 1.1.1 -> 10101
- * 0.7.0 -> 700
- * 99.99.99 -> 999999
- */
-fun getVersionCode(semver: String): Int? {
-	val parts = semver.splitToSequence('.')
-		.take(3)
-		.map { it.toIntOrNull() }
-		.filterNotNull()
-		.toList()
-
-	// Not a valid semver
-	if (parts.size != 3) return null
-
-	var code = 0
-	code += parts[0] * 10000 // Major (0-99)
-	code += parts[1] * 100 // Minor (0-99)
-	code += parts[2] // Patch (0-99)
-
-	return code
-}
-
 android {
 	compileSdkVersion(29)
 
@@ -64,14 +37,14 @@ android {
 }
 
 dependencies {
-	api(project(":library"))
+	apiProject(":library")
 
-	implementation(kotlin("stdlib-jdk8"))
+	implementationKotlinStdlib()
 
-	implementation("androidx.core:core-ktx:1.2.0")
-	implementation("androidx.annotation:annotation:1.1.0")
+	implementation(Dependencies.AndroidX.core)
+	implementation(Dependencies.AndroidX.annotation)
 
-	implementation("com.android.volley:volley:1.1.1")
+	implementation(Dependencies.volley)
 }
 
 // Because of limitations in the android plugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,15 +29,7 @@ allprojects {
 
 	// Publishing
 	plugins.apply("maven-publish")
-	publishing.repositories.maven {
-		name = "bintray"
-		url = uri("https://bintray.com/jellyfin/jellyfin-apiclient-java/jellyfin-apiclient-java;publish=1;override=1")
-
-		credentials {
-			username = getProperty("bintray.user") as String?
-			password = getProperty("bintray.key") as String?
-		}
-	}
+	publishing.repositories.jellyfinBintray(this)
 
 	// Detekt
 	plugins.apply("io.gitlab.arturbosch.detekt")
@@ -46,14 +38,4 @@ allprojects {
 		ignoreFailures = true
 		config = files("$rootDir/detekt.yml")
 	}
-}
-
-/**
- * Helper function to retrieve configuration variable values
- */
-fun getProperty(name: String): String? {
-	// sample.var --> SAMPLE_VAR
-	val environmentName = name.toUpperCase().replace(".", "_")
-
-	return project.findProperty(name)?.toString() ?: System.getenv(environmentName) ?: null
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+	`kotlin-dsl`
+}
+
+repositories {
+	jcenter()
+}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,0 +1,44 @@
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.kotlin.dsl.kotlin
+import org.gradle.kotlin.dsl.project
+
+object Dependencies {
+	object KotlinX {
+		private fun item(module: String, version: String) = "org.jetbrains.kotlinx:kotlinx-${module}:${version}"
+
+		val cli = item("cli", "0.2.1")
+		val coroutinesCore = item("coroutines-core", "1.3.5")
+	}
+
+	object AndroidX {
+		private fun item(library: String, module: String = library, version: String) = "androidx.${library}:${module}:${version}"
+
+		val core = item("core", "core-ktx", "1.3.0")
+		val annotation = item("annotation", version = "1.1.0")
+	}
+
+	// Non-categorised dependencies
+	const val volley = "com.android.volley:volley:1.1.1"
+	const val gson = "com.google.code.gson:gson:2.8.6"
+	const val javaWebSocket = "org.java-websocket:Java-WebSocket:1.4.1"
+	const val junit = "junit:junit:4.12"
+}
+
+/**
+ * Add given project as api
+ */
+fun DependencyHandler.apiProject(path: String) {
+	add("api", project(path))
+}
+
+/**
+ * Add given project as implementation
+ */
+fun DependencyHandler.implementationProject(path: String) {
+	add("implementation", project(path))
+}
+
+/**
+ * Add the Kotlin standard library as implementation
+ */
+fun DependencyHandler.implementationKotlinStdlib() = kotlin("stdlib")

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -41,4 +41,4 @@ fun DependencyHandler.implementationProject(path: String) {
 /**
  * Add the Kotlin standard library as implementation
  */
-fun DependencyHandler.implementationKotlinStdlib() = kotlin("stdlib")
+fun DependencyHandler.implementationKotlinStdlib() = add("implementation", kotlin("stdlib"))

--- a/buildSrc/src/main/kotlin/Properties.kt
+++ b/buildSrc/src/main/kotlin/Properties.kt
@@ -1,0 +1,11 @@
+import org.gradle.api.Project
+
+/**
+ * Helper function to retrieve configuration variable values
+ */
+fun Project.getProperty(name: String): String? {
+	// sample.var --> SAMPLE_VAR
+	val environmentName = name.toUpperCase().replace(".", "_")
+
+	return findProperty(name)?.toString() ?: System.getenv(environmentName) ?: null
+}

--- a/buildSrc/src/main/kotlin/Publishing.kt
+++ b/buildSrc/src/main/kotlin/Publishing.kt
@@ -1,0 +1,12 @@
+import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+
+fun RepositoryHandler.jellyfinBintray(project: Project) = maven {
+	name = "bintray"
+	url = project.uri("https://bintray.com/jellyfin/jellyfin-apiclient-java/jellyfin-apiclient-java;publish=1;override=1")
+
+	credentials {
+		username = project.getProperty("bintray.user")
+		password = project.getProperty("bintray.key")
+	}
+}

--- a/buildSrc/src/main/kotlin/Semver.kt
+++ b/buildSrc/src/main/kotlin/Semver.kt
@@ -10,8 +10,7 @@
 fun getVersionCode(semver: String): Int? {
 	val parts = semver.splitToSequence('.')
 		.take(3)
-		.map { it.toIntOrNull() }
-		.filterNotNull()
+		.mapNotNull { it.toIntOrNull() }
 		.toList()
 
 	// Not a valid semver

--- a/buildSrc/src/main/kotlin/Semver.kt
+++ b/buildSrc/src/main/kotlin/Semver.kt
@@ -1,0 +1,26 @@
+/**
+ * Get the versioncode for a given semver. Returns null if value is invalid.
+ *
+ * Sample output:
+ * 0.0.0 -> 0
+ * 1.1.1 -> 10101
+ * 0.7.0 -> 700
+ * 99.99.99 -> 999999
+ */
+fun getVersionCode(semver: String): Int? {
+	val parts = semver.splitToSequence('.')
+		.take(3)
+		.map { it.toIntOrNull() }
+		.filterNotNull()
+		.toList()
+
+	// Not a valid semver
+	if (parts.size != 3) return null
+
+	var code = 0
+	code += parts[0] * 10000 // Major (0-99)
+	code += parts[1] * 100 // Minor (0-99)
+	code += parts[2] // Patch (0-99)
+
+	return code
+}

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -3,15 +3,15 @@ plugins {
 }
 
 dependencies {
-	api(project(":model"))
+	apiProject(":model")
 
-	implementation(kotlin("stdlib-jdk7"))
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5")
+	implementationKotlinStdlib()
+	implementation(Dependencies.KotlinX.coroutinesCore)
 
-	implementation("org.java-websocket:Java-WebSocket:1.4.1")
-	implementation("com.google.code.gson:gson:2.8.6")
+	implementation(Dependencies.javaWebSocket)
+	implementation(Dependencies.gson)
 
-	testImplementation("junit:junit:4.12")
+	testImplementation(Dependencies.junit)
 }
 
 val sourcesJar by tasks.creating(Jar::class) {

--- a/samples/kotlin-console/build.gradle.kts
+++ b/samples/kotlin-console/build.gradle.kts
@@ -16,19 +16,19 @@ repositories {
 
 dependencies {
 	// Depend on the library project
-	implementation(project(":library"))
+	implementationProject(":library")
 
 	// Use Kotlin stdlib
-	implementation(kotlin("stdlib"))
+	implementationKotlinStdlib()
 
 	// Use Kotlin coroutines to interact with the library
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5")
+	implementation(Dependencies.KotlinX.coroutinesCore)
 
 	// The CLI library
-	implementation("org.jetbrains.kotlinx:kotlinx-cli:0.2.1")
+	implementation(Dependencies.KotlinX.cli)
 
 	// Use JSON
-	implementation("com.google.code.gson:gson:2.8.6")
+	implementation(Dependencies.gson)
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {


### PR DESCRIPTION
This will solve some things:
- No need to paste functions inside of build.gradle.kts scripts, making those more readable
- Sharing dependency versions, update them in a single place
- Slightly improved build times (barely noticable)

Not a lot of code was added, it was mostly moving things around. Some new code in `Dependencies.kt` though.