### PR TITLE
Add env variable mapping

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,8 @@ jobs:
           testResultsFiles: '**/TEST-*.xml'
           javaHomeOption: 'JDKVersion'
           sonarQubeRunAnalysis: false
+        env:
+          bintray_key: $(bintray_key)
 
       - task: GithubRelease@0
         displayName: 'GitHub Upload'


### PR DESCRIPTION
To help add Bintray publishing as requested in #54/ #78. 

This is required to have access to the secret variable in the task.