### PR TITLE
Fix release assets uploading the wrong files

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,7 +81,7 @@ jobs:
           gitHubConnection: Jellyfin Release Download
           repositoryName: jellyfin/jellyfin-apiclient-java
           assets: |
-            "**/distributions/*-${JELLYFIN_VERSION}.zip
+            **/distributions/*-${JELLYFIN_VERSION}.zip
             **/libs/*-${JELLYFIN_VERSION}.jar
             **/libs/*-${JELLYFIN_VERSION}-sources.jar
           action: 'edit'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,10 +64,10 @@ jobs:
         displayName: 'Set Version Variable'
 
       - task: Gradle@2
-        displayName: 'Build & Publish'
+        displayName: 'Build, Distribute & Publish'
         inputs:
           gradleWrapperFile: 'gradlew'
-          tasks: 'publish'
+          tasks: 'publish distZip'
           publishJUnitResults: false
           testResultsFiles: '**/TEST-*.xml'
           javaHomeOption: 'JDKVersion'
@@ -80,7 +80,10 @@ jobs:
         inputs:
           gitHubConnection: Jellyfin Release Download
           repositoryName: jellyfin/jellyfin-apiclient-java
-          assets: '**/libs/*.jar'
+          assets: |
+            "**/distributions/*-${JELLYFIN_VERSION}.zip
+            **/libs/*-${JELLYFIN_VERSION}.jar
+            **/libs/*-${JELLYFIN_VERSION}-sources.jar
           action: 'edit'
           assetUploadMode: 'replace'
           tag: '$(JELLYFIN_VERSION)'


### PR DESCRIPTION
I did some testing and noticed that more .jar files were be picked up (buildSrc.jar). I made the glob more strict to only upload the generated libraries.
I also added distributions to the uploads, this currently includes a build of the console example (called "kotlin-console-$VERSION.zip") that includes all used libraries etc. for easy use.

The globs are made in a way that adding new samples or library modules won't require changes.