### PR TITLE
Fix incorrect Bintray repository URL

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
           javaHomeOption: 'JDKVersion'
           sonarQubeRunAnalysis: false
         env:
-          bintray_key: $(bintray_key)
+          BINTRAY_KEY: $(bintray_key)
 
       - task: GithubRelease@0
         displayName: 'GitHub Upload'

--- a/buildSrc/src/main/kotlin/Publishing.kt
+++ b/buildSrc/src/main/kotlin/Publishing.kt
@@ -3,7 +3,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 
 fun RepositoryHandler.jellyfinBintray(project: Project) = maven {
 	name = "bintray"
-	url = project.uri("https://bintray.com/jellyfin/jellyfin-apiclient-java/jellyfin-apiclient-java;publish=1;override=1")
+	url = project.uri("https://api.bintray.com/maven/jellyfin/jellyfin-apiclient-java/jellyfin-apiclient-java/;publish=1;override=1")
 
 	credentials {
 		username = project.getProperty("bintray.user")


### PR DESCRIPTION
Also makes the environment variable for the key uppercase. It shouldn't matter but it looks prettier.