### PR TITLE
Add minimal API module with hardcoded Authorization header

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+	id("kotlin")
+}
+
+dependencies {
+	implementation(kotlin("stdlib-jdk7"))
+
+	api(project(":model"))
+
+	// HTTP
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
+	implementation("io.ktor:ktor-client-okhttp:1.3.2")
+	implementation("io.ktor:ktor-client-gson:1.3.2")
+
+	// Testing
+	testImplementation(kotlin("test-junit"))
+}
+
+sourceSets.getByName("main").java.srcDir("src/main/kotlin-generated")
+
+val sourcesJar by tasks.creating(Jar::class) {
+	archiveClassifier.set("sources")
+
+	from(sourceSets.getByName("main").allSource)
+}
+
+publishing.publications.create<MavenPublication>("default") {
+	from(components["kotlin"])
+
+	artifact(sourcesJar)
+}

--- a/api/src/main/kotlin/org/jellyfin/apiclient/api/client/KtorClient.kt
+++ b/api/src/main/kotlin/org/jellyfin/apiclient/api/client/KtorClient.kt
@@ -1,0 +1,141 @@
+package org.jellyfin.apiclient.api.client
+
+import com.google.gson.FieldNamingPolicy
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.features.json.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import org.jellyfin.apiclient.api.client.adapter.LocalDateTimeTypeAdapter
+import org.jellyfin.apiclient.api.client.adapter.UUIDTypeAdapter
+import java.time.LocalDateTime
+import java.util.*
+
+open class KtorClient(
+	var baseUrl: String
+) {
+	val client = HttpClient {
+		install(JsonFeature) {
+			serializer = GsonSerializer {
+				setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
+				serializeNulls()
+				registerTypeAdapter(UUID::class.java, UUIDTypeAdapter())
+				registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeTypeAdapter())
+			}
+		}
+	}
+
+	/**
+	 * Replaces the variables in a path with the values in the map.
+	 * Will also remove trailing and repeated slashes
+	 */
+	fun createPath(path: String, pathParameters: Map<String, Any?>) = path
+		.split('/')
+		.filterNot { it.isEmpty() }
+		.map { rawName ->
+			val name = rawName.removeSurrounding(prefix = "{", suffix = "}")
+
+			// only act if the name actually is a variable
+			if (name != rawName) {
+				val value = pathParameters[name] ?: throw MissingPathVariableError(name, path)
+				return@map value.toString().encodeURLParameter(true)
+			}
+
+			return@map rawName
+		}
+		.joinToString("/")
+
+
+	fun createAuthorizationHeader(): String? {
+		// TODO retrieve this via the library module (future PR)
+		val params = mutableMapOf(
+			"Client" to "CLIENTNAME",
+			"Device" to "DEVICENAME",
+			"DeviceId" to "DEVICEID",
+			"Version" to "VERSION"
+		)
+
+//		params["Token"] = ""
+
+		// Format: `MediaBrowser key="value", key="value"`
+		return params.entries.joinToString(
+			separator = ", ",
+			prefix = "MediaBrowser ",
+			transform = {
+				// key="value"
+				"${it.key}=\"${it.value}\""
+			})
+	}
+
+	suspend inline fun <reified T> request(
+		method: HttpMethod = HttpMethod.Get,
+		path: String,
+		queryParameters: Map<String, Any?> = emptyMap(),
+		body: Any? = null
+	): Response<T> {
+		val response = client.request<HttpResponse> {
+			this.method = method
+
+			url {
+				// Create from base URL
+				takeFrom(baseUrl)
+
+				// Assign path
+				encodedPath = "${encodedPath.trimEnd('/')}/${path.trimStart('/')}"
+
+				// Append query parameters
+				queryParameters
+					.filterNot { it.value == null }
+					.forEach {
+						parameters.append(it.key, it.value.toString())
+					}
+			}
+
+			header("X-Emby-Authorization", createAuthorizationHeader())
+
+			if (body != null) {
+				contentType(ContentType.Application.Json)
+				this.body = body
+			}
+		}
+
+		return Response(response.receive())
+	}
+
+	suspend inline fun <reified T> get(
+		pathTemplate: String,
+		pathParameters: Map<String, Any?> = emptyMap(),
+		queryParameters: Map<String, Any?> = emptyMap(),
+		body: Any? = null
+	) = request<T>(
+		method = HttpMethod.Get,
+		path = createPath(pathTemplate, pathParameters),
+		queryParameters = queryParameters,
+		body = body
+	)
+
+	suspend inline fun <reified T> post(
+		pathTemplate: String,
+		pathParameters: Map<String, Any?> = emptyMap(),
+		queryParameters: Map<String, Any?> = emptyMap(),
+		body: Any? = null
+	) = request<T>(
+		method = HttpMethod.Post,
+		path = createPath(pathTemplate, pathParameters),
+		queryParameters = queryParameters,
+		body = body
+	)
+
+	suspend inline fun <reified T> delete(
+		pathTemplate: String,
+		pathParameters: Map<String, Any?> = emptyMap(),
+		queryParameters: Map<String, Any?> = emptyMap(),
+		body: Any? = null
+	) = request<T>(
+		method = HttpMethod.Delete,
+		path = createPath(pathTemplate, pathParameters),
+		queryParameters = queryParameters,
+		body = body
+	)
+}

--- a/api/src/main/kotlin/org/jellyfin/apiclient/api/client/KtorClient.kt
+++ b/api/src/main/kotlin/org/jellyfin/apiclient/api/client/KtorClient.kt
@@ -70,7 +70,8 @@ open class KtorClient(
 
 	suspend inline fun <reified T> request(
 		method: HttpMethod = HttpMethod.Get,
-		path: String,
+		pathTemplate: String,
+		pathParameters: Map<String, Any?> = emptyMap(),
 		queryParameters: Map<String, Any?> = emptyMap(),
 		body: Any? = null
 	): Response<T> {
@@ -81,7 +82,9 @@ open class KtorClient(
 				// Create from base URL
 				takeFrom(baseUrl)
 
-				// Assign path
+				// Replace path variables
+				val path = createPath(pathTemplate, pathParameters)
+				// Assign path making sure to remove duplicated slashes between the base and appended path
 				encodedPath = "${encodedPath.trimEnd('/')}/${path.trimStart('/')}"
 
 				// Append query parameters
@@ -110,7 +113,8 @@ open class KtorClient(
 		body: Any? = null
 	) = request<T>(
 		method = HttpMethod.Get,
-		path = createPath(pathTemplate, pathParameters),
+		pathTemplate = pathTemplate,
+		pathParameters = pathParameters,
 		queryParameters = queryParameters,
 		body = body
 	)
@@ -122,7 +126,8 @@ open class KtorClient(
 		body: Any? = null
 	) = request<T>(
 		method = HttpMethod.Post,
-		path = createPath(pathTemplate, pathParameters),
+		pathTemplate = pathTemplate,
+		pathParameters = pathParameters,
 		queryParameters = queryParameters,
 		body = body
 	)
@@ -134,7 +139,8 @@ open class KtorClient(
 		body: Any? = null
 	) = request<T>(
 		method = HttpMethod.Delete,
-		path = createPath(pathTemplate, pathParameters),
+		pathTemplate = pathTemplate,
+		pathParameters = pathParameters,
 		queryParameters = queryParameters,
 		body = body
 	)

--- a/api/src/main/kotlin/org/jellyfin/apiclient/api/client/MissingPathVariableError.kt
+++ b/api/src/main/kotlin/org/jellyfin/apiclient/api/client/MissingPathVariableError.kt
@@ -1,0 +1,6 @@
+package org.jellyfin.apiclient.api.client
+
+class MissingPathVariableError(
+	name: String,
+	path: String
+) : Error("Missing path variable $name from path $path")

--- a/api/src/main/kotlin/org/jellyfin/apiclient/api/client/Response.kt
+++ b/api/src/main/kotlin/org/jellyfin/apiclient/api/client/Response.kt
@@ -1,0 +1,12 @@
+package org.jellyfin.apiclient.api.client
+
+import kotlin.reflect.KProperty
+
+class Response<T>(
+	private val data: T
+) {
+	@JvmSynthetic
+	operator fun getValue(thisRef: Any?, property: KProperty<*>): T = data
+
+	fun getData() = data
+}

--- a/api/src/main/kotlin/org/jellyfin/apiclient/api/client/adapter/LocalDateTimeTypeAdapter.kt
+++ b/api/src/main/kotlin/org/jellyfin/apiclient/api/client/adapter/LocalDateTimeTypeAdapter.kt
@@ -1,0 +1,21 @@
+package org.jellyfin.apiclient.api.client.adapter
+
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/**
+ * Adapter to read zoned date times as local date time and writing it back
+ */
+class LocalDateTimeTypeAdapter : TypeAdapter<LocalDateTime>() {
+	override fun write(out: JsonWriter, value: LocalDateTime?) {
+		out.value(value?.atZone(ZoneId.systemDefault()).toString())
+	}
+
+	override fun read(`in`: JsonReader): LocalDateTime {
+		return ZonedDateTime.parse(`in`.nextString()).toLocalDateTime()
+	}
+}

--- a/api/src/main/kotlin/org/jellyfin/apiclient/api/client/adapter/UUIDTypeAdapter.kt
+++ b/api/src/main/kotlin/org/jellyfin/apiclient/api/client/adapter/UUIDTypeAdapter.kt
@@ -1,0 +1,26 @@
+package org.jellyfin.apiclient.api.client.adapter
+
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import java.util.*
+
+/**
+ * A custom UUID type adapter that supports the badly formatted UUIDs from the Jellyfin API
+ */
+class UUIDTypeAdapter : TypeAdapter<UUID>() {
+	override fun write(out: JsonWriter, value: UUID?) {
+		out.value(value?.toString())
+	}
+
+	override fun read(`in`: JsonReader): UUID {
+		val uuid = `in`.nextString()
+
+		return if (uuid.length == 32) UUID.fromString(uuid.replace(UUID_REGEX, "$1-$2-$3-$4-$5"))
+		else UUID.fromString(uuid)
+	}
+
+	companion object {
+		val UUID_REGEX = "^([a-z\\d]{8})([a-z\\d]{4})(4[a-z\\d]{3})([a-z\\d]{4})([a-z\\d]{12})\$".toRegex()
+	}
+}

--- a/api/src/test/kotlin/org/jellyfin/apiclient/api/client/KtorClientTests.kt
+++ b/api/src/test/kotlin/org/jellyfin/apiclient/api/client/KtorClientTests.kt
@@ -1,0 +1,68 @@
+package org.jellyfin.apiclient.api.client
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class KtorClientTests {
+	private fun createClient() = KtorClient("https://demo.jellyfin.org/stable/")
+
+	@Test
+	fun `createPath replaces values`() {
+		val instance = createClient()
+		val path = "/test/{one}/{two}/three"
+		val parameters = mapOf(
+			"one" to "1",
+			"two" to "2",
+			"three" to "3"
+		)
+
+		assertEquals("test/1/2/three", instance.createPath(path, parameters))
+	}
+
+	@Test
+	fun `createPath removes repeated slashes`() {
+		val instance = createClient()
+		val path = "test/1//2////three"
+
+		assertEquals("test/1/2/three", instance.createPath(path, emptyMap()))
+	}
+
+	@Test
+	fun `createPath fails when parameters are missing`() {
+		val instance = createClient()
+		val path = "/test/{one}/{two}/three"
+		val parameters = mapOf(
+			"one" to "1",
+			"three" to "3"
+		)
+
+		assertFails { instance.createPath(path, parameters) }
+	}
+
+	@Test
+	fun `createPath replaces integers`() {
+		val instance = createClient()
+		val path = "/test/{one}/{two}/three"
+		val parameters = mapOf(
+			"one" to 1,
+			"two" to 2,
+			"three" to 3
+		)
+
+		assertEquals("test/1/2/three", instance.createPath(path, parameters))
+	}
+
+	@Test
+	fun `createPath escapes values`() {
+		val instance = createClient()
+		val path = "/test/{one}/{two}/three"
+		val parameters = mapOf(
+			"one" to "1/0",
+			"two" to "value with whitespace",
+			"three" to 3
+		)
+
+		assertEquals("test/1%2F0/value+with+whitespace/three", instance.createPath(path, parameters))
+	}
+}

--- a/api/src/test/kotlin/org/jellyfin/apiclient/api/client/adapter/UUIDTypeAdapterTests.kt
+++ b/api/src/test/kotlin/org/jellyfin/apiclient/api/client/adapter/UUIDTypeAdapterTests.kt
@@ -1,0 +1,26 @@
+package org.jellyfin.apiclient.api.client.adapter
+
+import com.google.gson.stream.JsonReader
+import java.util.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UUIDTypeAdapterTests {
+	private fun String.asJsonReader() = JsonReader("\"$this\"".reader())
+
+	@Test
+	fun `Parses correctly formatted UUIDs`() {
+		val instance = UUIDTypeAdapter()
+
+		assertEquals(UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"), instance.read("713dc3fe-952b-438f-a70e-d35e4ef0525a".asJsonReader()))
+		assertEquals(UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"), instance.read("713dc3fe-952b-438f-a70e-d35e4ef0525a".asJsonReader()))
+	}
+
+	@Test
+	fun `Parses UUIDs formatted without dashes`() {
+		val instance = UUIDTypeAdapter()
+
+		assertEquals(UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"), instance.read("713dc3fe952b438fa70ed35e4ef0525a".asJsonReader()))
+		assertEquals(UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"), instance.read("713dc3fe952b438fa70ed35e4ef0525a".asJsonReader()))
+	}
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 // Core
 include(":library")
 include(":model")
+include(":api")
 
 // Platforms
 include(":android")


### PR DESCRIPTION
Part **3** of multiple

Merge after #92 


The current implementation is minimal and some code is missing (extensions + java compat). API calls use Kotlin delegates to make pretty code. Calling an API will look like this:

```kotlin
fun `authentication test`() = runBlocking {
	val userApi = UserApi(...)

	val auth: Response<AuthenticationResult> = userApi.authenticateUserByName("demo", "")
	val authDelegated: AuthenticationResult by userApi.authenticateUserByName("demo", "")
}
```