### PR TITLE
Add Java compatibility to api module

### DIFF
--- a/api/src/main/kotlin/org/jellyfin/apiclient/api/client/compatibility/JavaCallback.kt
+++ b/api/src/main/kotlin/org/jellyfin/apiclient/api/client/compatibility/JavaCallback.kt
@@ -1,0 +1,13 @@
+package org.jellyfin.apiclient.api.client.compatibility
+
+import org.jellyfin.apiclient.api.client.Response
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+abstract class JavaCallback<T> : Continuation<Response<T>> {
+	override val context: CoroutineContext = EmptyCoroutineContext
+	override fun resumeWith(result: Result<Response<T>>) = onResponse(result.getOrNull())
+
+	abstract fun onResponse(response: Response<T>?)
+}

--- a/api/src/main/kotlin/org/jellyfin/apiclient/api/client/compatibility/JavaDataCallback.kt
+++ b/api/src/main/kotlin/org/jellyfin/apiclient/api/client/compatibility/JavaDataCallback.kt
@@ -1,0 +1,13 @@
+package org.jellyfin.apiclient.api.client.compatibility
+
+import org.jellyfin.apiclient.api.client.Response
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+abstract class JavaDataCallback<T> : Continuation<Response<T>> {
+	override val context: CoroutineContext = EmptyCoroutineContext
+	override fun resumeWith(result: Result<Response<T>>) = onData(result.getOrNull()?.getData())
+
+	abstract fun onData(data: T?)
+}


### PR DESCRIPTION
Part **4** of multiple

Merge after #94 

Coroutines in Java aren't really a thing, this PR adds a solution to use the API in Java. Sample:

```java
        UserApi instance = new UserApi(createClient());
        AuthenticateUserByName data = new AuthenticateUserByName("demo", null, "");

        instance.authenticateUserByName(data, new JavaCallback<AuthenticationResult>() {
            @Override
            public void onResponse(@Nullable Response<AuthenticationResult> response) {
                assert response != null;

                System.out.println(response.getData());
            }
        });
```
```java
        UserApi instance = new UserApi(createClient());
        AuthenticateUserByName data = new AuthenticateUserByName("demo", null, "");

        instance.authenticateUserByName(data, new JavaDataCallback<AuthenticationResult>() {
            @Override
            public void onData(@Nullable AuthenticationResult data) {
                assert data != null;

                System.out.println(data);
            }
        });
```