### PR TITLE
Add UserApi.authenticateUserByName extension

### DIFF
--- a/api/src/main/kotlin/org/jellyfin/apiclient/api/client/extensions/UserApiExtensions.kt
+++ b/api/src/main/kotlin/org/jellyfin/apiclient/api/client/extensions/UserApiExtensions.kt
@@ -1,0 +1,14 @@
+package org.jellyfin.apiclient.api.client.extensions
+
+import org.jellyfin.apiclient.api.operations.UserApi
+import org.jellyfin.apiclient.model.AuthenticateUserByName
+
+/**
+ * Extension function for the authenticateUserByName operation that accepts the username and password directly
+ */
+suspend inline fun UserApi.authenticateUserByName(username: String, password: String) = authenticateUserByName(
+	data = AuthenticateUserByName(
+		username = username,
+		password = password
+	)
+)


### PR DESCRIPTION
Part **5** of multiple

Merge after #94

Currently just a single extension but the idea is to add more in the future. These extensions help simplifying API usage.

```kotlin
// Before
userApi.authenticateUserByName(AuthenticateUserByName(username = "demo", pw = null, password = "demo"))
// After
userApi.authenticateUserByName(username = "demo", password = "demo")
```