### PR TITLE
Use buildSrc in new modules

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 dependencies {
 	apiProject(":library")
 
-	implementationKotlinStdlib()
+	implementation(Dependencies.Kotlin.stdlib)
 
 	implementation(Dependencies.AndroidX.core)
 	implementation(Dependencies.AndroidX.annotation)

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -3,17 +3,17 @@ plugins {
 }
 
 dependencies {
-	implementation(kotlin("stdlib-jdk7"))
+	implementation(Dependencies.Kotlin.stdlib)
 
-	api(project(":model"))
+	apiProject(":model")
 
 	// HTTP
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
-	implementation("io.ktor:ktor-client-okhttp:1.3.2")
-	implementation("io.ktor:ktor-client-gson:1.3.2")
+	implementation(Dependencies.KotlinX.coroutinesCore)
+	implementation(Dependencies.Ktor.okhttp)
+	implementation(Dependencies.Ktor.gson)
 
 	// Testing
-	testImplementation(kotlin("test-junit"))
+	testImplementation(Dependencies.Kotlin.Test.junit)
 }
 
 sourceSets.getByName("main").java.srcDir("src/main/kotlin-generated")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,8 +16,8 @@ buildscript {
 	}
 
 	dependencies {
-		classpath("com.android.tools.build:gradle:4.0.1")
-		classpath(kotlin("gradle-plugin", "1.3.72"))
+		classpath(Dependencies.androidBuildTools)
+		classpath(Dependencies.Kotlin.gradlePlugin)
 	}
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,5 +1,4 @@
 import org.gradle.api.artifacts.dsl.DependencyHandler
-import org.gradle.kotlin.dsl.kotlin
 import org.gradle.kotlin.dsl.project
 
 object Dependencies {
@@ -7,7 +6,7 @@ object Dependencies {
 		private fun item(module: String, version: String) = "org.jetbrains.kotlinx:kotlinx-${module}:${version}"
 
 		val cli = item("cli", "0.2.1")
-		val coroutinesCore = item("coroutines-core", "1.3.5")
+		val coroutinesCore = item("coroutines-core", "1.3.9")
 	}
 
 	object AndroidX {
@@ -17,11 +16,43 @@ object Dependencies {
 		val annotation = item("annotation", version = "1.1.0")
 	}
 
+	object Kotlin {
+		private const val version = "1.3.72"
+		private fun item(library: String) = "org.jetbrains.kotlin:kotlin-$library:$version"
+
+		val stdlib = item("stdlib")
+		val gradlePlugin = item("gradle-plugin")
+
+		object Test {
+			private fun testItem(library: String) = item("test-$library")
+
+			val junit = testItem("junit")
+		}
+	}
+
+	object Ktor {
+		private const val version = "1.3.2"
+		private fun item(library: String) = "io.ktor:ktor-$library:$version"
+
+		val okhttp = item("client-okhttp")
+		val gson = item("client-gson")
+	}
+
+	object Koin {
+		private const val version = "2.1.6"
+		private fun item(module: String) = "org.koin:koin-$module:$version"
+
+		val core = item("core")
+	}
+
 	// Non-categorised dependencies
+	const val androidBuildTools = "com.android.tools.build:gradle:4.0.1"
 	const val volley = "com.android.volley:volley:1.1.1"
 	const val gson = "com.google.code.gson:gson:2.8.6"
 	const val javaWebSocket = "org.java-websocket:Java-WebSocket:1.4.1"
 	const val junit = "junit:junit:4.12"
+	const val swaggerParser = "io.swagger.parser.v3:swagger-parser:2.0.19"
+	const val kotlinPoet = "com.squareup:kotlinpoet:1.6.0"
 }
 
 /**
@@ -37,8 +68,3 @@ fun DependencyHandler.apiProject(path: String) {
 fun DependencyHandler.implementationProject(path: String) {
 	add("implementation", project(path))
 }
-
-/**
- * Add the Kotlin standard library as implementation
- */
-fun DependencyHandler.implementationKotlinStdlib() = add("implementation", kotlin("stdlib"))

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
 	apiProject(":model")
 
-	implementationKotlinStdlib()
+	implementation(Dependencies.Kotlin.stdlib)
 	implementation(Dependencies.KotlinX.coroutinesCore)
 
 	implementation(Dependencies.javaWebSocket)

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-	implementation(kotlin("stdlib-jdk7"))
+	implementation(Dependencies.Kotlin.stdlib)
 }
 
 sourceSets.getByName("main").java.srcDir("src/main/kotlin-generated")

--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -8,19 +8,19 @@ application {
 }
 
 dependencies {
-	implementation(kotlin("stdlib-jdk8"))
+	implementation(Dependencies.Kotlin.stdlib)
 
 	// Reading OpenAPI
-	implementation("io.swagger.parser.v3:swagger-parser:2.0.19")
+	implementation(Dependencies.swaggerParser)
 
 	// Kotlin code generation
-	implementation("com.squareup:kotlinpoet:1.6.0")
+	implementation(Dependencies.kotlinPoet)
 
 	// Dependency Injection
-	implementation("org.koin:koin-core:2.1.6")
+	implementation(Dependencies.Koin.core)
 
 	// Testing
-	testImplementation(kotlin("test-junit"))
+	testImplementation(Dependencies.Kotlin.Test.junit)
 }
 
 task("generateSources", JavaExec::class) {

--- a/samples/kotlin-console/build.gradle.kts
+++ b/samples/kotlin-console/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 	implementationProject(":library")
 
 	// Use Kotlin stdlib
-	implementationKotlinStdlib()
+	implementation(Dependencies.Kotlin.stdlib)
 
 	// Use Kotlin coroutines to interact with the library
 	implementation(Dependencies.KotlinX.coroutinesCore)


### PR DESCRIPTION
The buildSrc structure wasn't added yet when I started on the OpenAPI branch and updating would be a pain before everything was merged. So here it is!

Fixes the mix of stdlib-jdk7 and stdlib-jdk8.

I did not update the versions, although using Kotlin 1.4 is planned when the new kotlinpoet release is released.