### PR TITLE
Nullable references

### DIFF
--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/AccessSchedule.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/AccessSchedule.kt
@@ -31,7 +31,7 @@ data class AccessSchedule(
 	@SerialName("UserId")
 	val userId: UUID,
 	@SerialName("DayOfWeek")
-	val dayOfWeek: DynamicDayOfWeek,
+	val dayOfWeek: DynamicDayOfWeek? = null,
 	/**
 	 * Gets or sets the start hour.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ActivityLogEntry.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ActivityLogEntry.kt
@@ -70,5 +70,5 @@ data class ActivityLogEntry(
 	@SerialName("UserPrimaryImageTag")
 	val userPrimaryImageTag: String? = null,
 	@SerialName("Severity")
-	val severity: LogLevel
+	val severity: LogLevel? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/AddVirtualFolderDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/AddVirtualFolderDto.kt
@@ -14,5 +14,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AddVirtualFolderDto(
 	@SerialName("LibraryOptions")
-	val libraryOptions: LibraryOptions
+	val libraryOptions: LibraryOptions? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/AlbumInfoRemoteSearchQuery.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/AlbumInfoRemoteSearchQuery.kt
@@ -18,7 +18,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 @Serializable
 data class AlbumInfoRemoteSearchQuery(
 	@SerialName("SearchInfo")
-	val searchInfo: AlbumInfo,
+	val searchInfo: AlbumInfo? = null,
 	@SerialName("ItemId")
 	val itemId: UUID,
 	/**

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/AllThemeMediaResult.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/AllThemeMediaResult.kt
@@ -11,9 +11,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AllThemeMediaResult(
 	@SerialName("ThemeVideosResult")
-	val themeVideosResult: ThemeMediaResult,
+	val themeVideosResult: ThemeMediaResult? = null,
 	@SerialName("ThemeSongsResult")
-	val themeSongsResult: ThemeMediaResult,
+	val themeSongsResult: ThemeMediaResult? = null,
 	@SerialName("SoundtrackSongsResult")
-	val soundtrackSongsResult: ThemeMediaResult
+	val soundtrackSongsResult: ThemeMediaResult? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ArtistInfoRemoteSearchQuery.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ArtistInfoRemoteSearchQuery.kt
@@ -18,7 +18,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 @Serializable
 data class ArtistInfoRemoteSearchQuery(
 	@SerialName("SearchInfo")
-	val searchInfo: ArtistInfo,
+	val searchInfo: ArtistInfo? = null,
 	@SerialName("ItemId")
 	val itemId: UUID,
 	/**

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/AuthenticationResult.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/AuthenticationResult.kt
@@ -12,9 +12,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AuthenticationResult(
 	@SerialName("User")
-	val user: UserDto,
+	val user: UserDto? = null,
 	@SerialName("SessionInfo")
-	val sessionInfo: SessionInfo,
+	val sessionInfo: SessionInfo? = null,
 	@SerialName("AccessToken")
 	val accessToken: String? = null,
 	@SerialName("ServerId")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/BaseItemDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/BaseItemDto.kt
@@ -104,7 +104,7 @@ data class BaseItemDto(
 	@SerialName("ForcedSortName")
 	val forcedSortName: String? = null,
 	@SerialName("Video3DFormat")
-	val video3DFormat: Video3DFormat,
+	val video3DFormat: Video3DFormat? = null,
 	/**
 	 * Gets or sets the premiere date.
 	 */
@@ -182,7 +182,7 @@ data class BaseItemDto(
 	@SerialName("RunTimeTicks")
 	val runTimeTicks: Long? = null,
 	@SerialName("PlayAccess")
-	val playAccess: PlayAccess,
+	val playAccess: PlayAccess? = null,
 	/**
 	 * Gets or sets the aspect ratio.
 	 */
@@ -283,7 +283,7 @@ data class BaseItemDto(
 	@SerialName("LocalTrailerCount")
 	val localTrailerCount: Int? = null,
 	@SerialName("UserData")
-	val userData: UserItemDataDto,
+	val userData: UserItemDataDto? = null,
 	/**
 	 * Gets or sets the recursive item count.
 	 */
@@ -405,7 +405,7 @@ data class BaseItemDto(
 	@SerialName("MediaStreams")
 	val mediaStreams: List<MediaStream>? = null,
 	@SerialName("VideoType")
-	val videoType: VideoType,
+	val videoType: VideoType? = null,
 	/**
 	 * Gets or sets the part count.
 	 */
@@ -485,9 +485,9 @@ data class BaseItemDto(
 	@SerialName("Chapters")
 	val chapters: List<ChapterInfo>? = null,
 	@SerialName("LocationType")
-	val locationType: LocationType,
+	val locationType: LocationType? = null,
 	@SerialName("IsoType")
-	val isoType: IsoType,
+	val isoType: IsoType? = null,
 	/**
 	 * Gets or sets the type of the media.
 	 */
@@ -562,7 +562,7 @@ data class BaseItemDto(
 	@SerialName("FocalLength")
 	val focalLength: Double? = null,
 	@SerialName("ImageOrientation")
-	val imageOrientation: ImageOrientation,
+	val imageOrientation: ImageOrientation? = null,
 	@SerialName("Aperture")
 	val aperture: Double? = null,
 	@SerialName("ShutterSpeed")
@@ -611,9 +611,9 @@ data class BaseItemDto(
 	@SerialName("EpisodeTitle")
 	val episodeTitle: String? = null,
 	@SerialName("ChannelType")
-	val channelType: ChannelType,
+	val channelType: ChannelType? = null,
 	@SerialName("Audio")
-	val audio: ProgramAudio,
+	val audio: ProgramAudio? = null,
 	/**
 	 * Gets or sets a value indicating whether this instance is movie.
 	 */
@@ -655,5 +655,5 @@ data class BaseItemDto(
 	@SerialName("TimerId")
 	val timerId: String? = null,
 	@SerialName("CurrentProgram")
-	val currentProgram: BaseItemDto
+	val currentProgram: BaseItemDto? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/BookInfoRemoteSearchQuery.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/BookInfoRemoteSearchQuery.kt
@@ -18,7 +18,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 @Serializable
 data class BookInfoRemoteSearchQuery(
 	@SerialName("SearchInfo")
-	val searchInfo: BookInfo,
+	val searchInfo: BookInfo? = null,
 	@SerialName("ItemId")
 	val itemId: UUID,
 	/**

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/BoxSetInfoRemoteSearchQuery.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/BoxSetInfoRemoteSearchQuery.kt
@@ -18,7 +18,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 @Serializable
 data class BoxSetInfoRemoteSearchQuery(
 	@SerialName("SearchInfo")
-	val searchInfo: BoxSetInfo,
+	val searchInfo: BoxSetInfo? = null,
 	@SerialName("ItemId")
 	val itemId: UUID,
 	/**

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ClientCapabilities.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ClientCapabilities.kt
@@ -28,7 +28,7 @@ data class ClientCapabilities(
 	@SerialName("SupportsSync")
 	val supportsSync: Boolean,
 	@SerialName("DeviceProfile")
-	val deviceProfile: DeviceProfile,
+	val deviceProfile: DeviceProfile? = null,
 	@SerialName("AppStoreUrl")
 	val appStoreUrl: String? = null,
 	@SerialName("IconUrl")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/CodecProfile.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/CodecProfile.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CodecProfile(
 	@SerialName("Type")
-	val type: CodecType,
+	val type: CodecType? = null,
 	@SerialName("Conditions")
 	val conditions: List<ProfileCondition>? = null,
 	@SerialName("ApplyConditions")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ConfigurationPageInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ConfigurationPageInfo.kt
@@ -41,7 +41,7 @@ data class ConfigurationPageInfo(
 	@SerialName("DisplayName")
 	val displayName: String? = null,
 	@SerialName("ConfigurationPageType")
-	val configurationPageType: ConfigurationPageType,
+	val configurationPageType: ConfigurationPageType? = null,
 	/**
 	 * Gets or sets the plugin id.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ContainerProfile.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ContainerProfile.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ContainerProfile(
 	@SerialName("Type")
-	val type: DlnaProfileType,
+	val type: DlnaProfileType? = null,
 	@SerialName("Conditions")
 	val conditions: List<ProfileCondition>? = null,
 	@SerialName("Container")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/DeviceInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/DeviceInfo.kt
@@ -54,7 +54,7 @@ data class DeviceInfo(
 	@SerialName("DateLastActivity")
 	val dateLastActivity: LocalDateTime,
 	@SerialName("Capabilities")
-	val capabilities: ClientCapabilities,
+	val capabilities: ClientCapabilities? = null,
 	@SerialName("IconUrl")
 	val iconUrl: String? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/DeviceProfile.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/DeviceProfile.kt
@@ -23,7 +23,7 @@ data class DeviceProfile(
 	@SerialName("Id")
 	val id: String? = null,
 	@SerialName("Identification")
-	val identification: DeviceIdentification,
+	val identification: DeviceIdentification? = null,
 	@SerialName("FriendlyName")
 	val friendlyName: String? = null,
 	@SerialName("Manufacturer")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/DeviceProfileDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/DeviceProfileDto.kt
@@ -14,5 +14,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class DeviceProfileDto(
 	@SerialName("DeviceProfile")
-	val deviceProfile: DeviceProfile
+	val deviceProfile: DeviceProfile? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/DeviceProfileInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/DeviceProfileInfo.kt
@@ -22,5 +22,5 @@ data class DeviceProfileInfo(
 	@SerialName("Name")
 	val name: String? = null,
 	@SerialName("Type")
-	val type: DeviceProfileType
+	val type: DeviceProfileType? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/DirectPlayProfile.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/DirectPlayProfile.kt
@@ -18,5 +18,5 @@ data class DirectPlayProfile(
 	@SerialName("VideoCodec")
 	val videoCodec: String? = null,
 	@SerialName("Type")
-	val type: DlnaProfileType
+	val type: DlnaProfileType? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/DisplayPreferencesDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/DisplayPreferencesDto.kt
@@ -58,7 +58,7 @@ data class DisplayPreferencesDto(
 	@SerialName("CustomPrefs")
 	val customPrefs: Map<String, String>? = null,
 	@SerialName("ScrollDirection")
-	val scrollDirection: ScrollDirection,
+	val scrollDirection: ScrollDirection? = null,
 	/**
 	 * Gets or sets a value indicating whether to show backdrops on this item.
 	 */
@@ -70,7 +70,7 @@ data class DisplayPreferencesDto(
 	@SerialName("RememberSorting")
 	val rememberSorting: Boolean,
 	@SerialName("SortOrder")
-	val sortOrder: SortOrder,
+	val sortOrder: SortOrder? = null,
 	/**
 	 * Gets or sets a value indicating whether [show sidebar].
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ExternalIdInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ExternalIdInfo.kt
@@ -25,7 +25,7 @@ data class ExternalIdInfo(
 	@SerialName("Key")
 	val key: String? = null,
 	@SerialName("Type")
-	val type: ExternalIdMediaType,
+	val type: ExternalIdMediaType? = null,
 	/**
 	 * Gets or sets the URL format string.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/FileSystemEntryInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/FileSystemEntryInfo.kt
@@ -25,5 +25,5 @@ data class FileSystemEntryInfo(
 	@SerialName("Path")
 	val path: String? = null,
 	@SerialName("Type")
-	val type: FileSystemEntryType
+	val type: FileSystemEntryType? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ForgotPasswordResult.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ForgotPasswordResult.kt
@@ -17,7 +17,7 @@ import org.jellyfin.apiclient.model.serializer.LocalDateTimeSerializer
 @Serializable
 data class ForgotPasswordResult(
 	@SerialName("Action")
-	val action: ForgotPasswordAction,
+	val action: ForgotPasswordAction? = null,
 	/**
 	 * Gets or sets the pin file.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/HttpHeaderInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/HttpHeaderInfo.kt
@@ -16,5 +16,5 @@ data class HttpHeaderInfo(
 	@SerialName("Value")
 	val value: String? = null,
 	@SerialName("Match")
-	val match: HeaderMatchType
+	val match: HeaderMatchType? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/IScheduledTaskWorker.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/IScheduledTaskWorker.kt
@@ -17,9 +17,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class IScheduledTaskWorker(
 	@SerialName("ScheduledTask")
-	val scheduledTask: IScheduledTask,
+	val scheduledTask: IScheduledTask? = null,
 	@SerialName("LastExecutionResult")
-	val lastExecutionResult: TaskResult,
+	val lastExecutionResult: TaskResult? = null,
 	/**
 	 * Gets the name.
 	 */
@@ -36,7 +36,7 @@ data class IScheduledTaskWorker(
 	@SerialName("Category")
 	val category: String? = null,
 	@SerialName("State")
-	val state: TaskState,
+	val state: TaskState? = null,
 	/**
 	 * Gets the current progress.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ImageInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ImageInfo.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ImageInfo(
 	@SerialName("ImageType")
-	val imageType: ImageType,
+	val imageType: ImageType? = null,
 	/**
 	 * Gets or sets the index of the image.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ImageOption.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ImageOption.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ImageOption(
 	@SerialName("Type")
-	val type: ImageType,
+	val type: ImageType? = null,
 	/**
 	 * Gets or sets the limit.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/InstallationInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/InstallationInfo.kt
@@ -30,7 +30,7 @@ data class InstallationInfo(
 	@SerialName("Name")
 	val name: String? = null,
 	@SerialName("Version")
-	val version: Version,
+	val version: Version? = null,
 	/**
 	 * Gets or sets the changelog for this version.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/LiveStreamResponse.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/LiveStreamResponse.kt
@@ -11,5 +11,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class LiveStreamResponse(
 	@SerialName("MediaSource")
-	val mediaSource: MediaSourceInfo
+	val mediaSource: MediaSourceInfo? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/LiveTvServiceInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/LiveTvServiceInfo.kt
@@ -27,7 +27,7 @@ data class LiveTvServiceInfo(
 	@SerialName("HomePageUrl")
 	val homePageUrl: String? = null,
 	@SerialName("Status")
-	val status: LiveTvServiceStatus,
+	val status: LiveTvServiceStatus? = null,
 	/**
 	 * Gets or sets the status message.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/MediaPathDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/MediaPathDto.kt
@@ -25,5 +25,5 @@ data class MediaPathDto(
 	@SerialName("Path")
 	val path: String? = null,
 	@SerialName("PathInfo")
-	val pathInfo: MediaPathInfo
+	val pathInfo: MediaPathInfo? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/MediaSourceInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/MediaSourceInfo.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MediaSourceInfo(
 	@SerialName("Protocol")
-	val protocol: MediaProtocol,
+	val protocol: MediaProtocol? = null,
 	@SerialName("Id")
 	val id: String? = null,
 	@SerialName("Path")
@@ -25,9 +25,9 @@ data class MediaSourceInfo(
 	@SerialName("EncoderPath")
 	val encoderPath: String? = null,
 	@SerialName("EncoderProtocol")
-	val encoderProtocol: MediaProtocol,
+	val encoderProtocol: MediaProtocol? = null,
 	@SerialName("Type")
-	val type: MediaSourceType,
+	val type: MediaSourceType? = null,
 	@SerialName("Container")
 	val container: String? = null,
 	@SerialName("Size")
@@ -74,11 +74,11 @@ data class MediaSourceInfo(
 	@SerialName("SupportsProbing")
 	val supportsProbing: Boolean,
 	@SerialName("VideoType")
-	val videoType: VideoType,
+	val videoType: VideoType? = null,
 	@SerialName("IsoType")
-	val isoType: IsoType,
+	val isoType: IsoType? = null,
 	@SerialName("Video3DFormat")
-	val video3DFormat: Video3DFormat,
+	val video3DFormat: Video3DFormat? = null,
 	@SerialName("MediaStreams")
 	val mediaStreams: List<MediaStream>? = null,
 	@SerialName("MediaAttachments")
@@ -88,7 +88,7 @@ data class MediaSourceInfo(
 	@SerialName("Bitrate")
 	val bitrate: Int? = null,
 	@SerialName("Timestamp")
-	val timestamp: TransportStreamTimestamp,
+	val timestamp: TransportStreamTimestamp? = null,
 	@SerialName("RequiredHttpHeaders")
 	val requiredHttpHeaders: Map<String, String>? = null,
 	@SerialName("TranscodingUrl")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/MediaStream.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/MediaStream.kt
@@ -166,7 +166,7 @@ data class MediaStream(
 	@SerialName("Profile")
 	val profile: String? = null,
 	@SerialName("Type")
-	val type: MediaStreamType,
+	val type: MediaStreamType? = null,
 	/**
 	 * Gets or sets the aspect ratio.
 	 */
@@ -188,7 +188,7 @@ data class MediaStream(
 	@SerialName("IsExternal")
 	val isExternal: Boolean,
 	@SerialName("DeliveryMethod")
-	val deliveryMethod: SubtitleDeliveryMethod,
+	val deliveryMethod: SubtitleDeliveryMethod? = null,
 	/**
 	 * Gets or sets the delivery URL.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/MovieInfoRemoteSearchQuery.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/MovieInfoRemoteSearchQuery.kt
@@ -18,7 +18,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 @Serializable
 data class MovieInfoRemoteSearchQuery(
 	@SerialName("SearchInfo")
-	val searchInfo: MovieInfo,
+	val searchInfo: MovieInfo? = null,
 	@SerialName("ItemId")
 	val itemId: UUID,
 	/**

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/MusicVideoInfoRemoteSearchQuery.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/MusicVideoInfoRemoteSearchQuery.kt
@@ -18,7 +18,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 @Serializable
 data class MusicVideoInfoRemoteSearchQuery(
 	@SerialName("SearchInfo")
-	val searchInfo: MusicVideoInfo,
+	val searchInfo: MusicVideoInfo? = null,
 	@SerialName("ItemId")
 	val itemId: UUID,
 	/**

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/NotificationDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/NotificationDto.kt
@@ -56,5 +56,5 @@ data class NotificationDto(
 	@SerialName("Url")
 	val url: String? = null,
 	@SerialName("Level")
-	val level: NotificationLevel
+	val level: NotificationLevel? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/NotificationsSummaryDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/NotificationsSummaryDto.kt
@@ -20,5 +20,5 @@ data class NotificationsSummaryDto(
 	@SerialName("UnreadCount")
 	val unreadCount: Int,
 	@SerialName("MaxUnreadNotificationLevel")
-	val maxUnreadNotificationLevel: NotificationLevel
+	val maxUnreadNotificationLevel: NotificationLevel? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/OpenLiveStreamDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/OpenLiveStreamDto.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class OpenLiveStreamDto(
 	@SerialName("DeviceProfile")
-	val deviceProfile: DeviceProfile,
+	val deviceProfile: DeviceProfile? = null,
 	/**
 	 * Gets or sets the device play protocols.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PersonLookupInfoRemoteSearchQuery.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PersonLookupInfoRemoteSearchQuery.kt
@@ -18,7 +18,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 @Serializable
 data class PersonLookupInfoRemoteSearchQuery(
 	@SerialName("SearchInfo")
-	val searchInfo: PersonLookupInfo,
+	val searchInfo: PersonLookupInfo? = null,
 	@SerialName("ItemId")
 	val itemId: UUID,
 	/**

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PlaybackInfoResponse.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PlaybackInfoResponse.kt
@@ -26,5 +26,5 @@ data class PlaybackInfoResponse(
 	@SerialName("PlaySessionId")
 	val playSessionId: String? = null,
 	@SerialName("ErrorCode")
-	val errorCode: PlaybackErrorCode
+	val errorCode: PlaybackErrorCode? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PlaybackProgressInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PlaybackProgressInfo.kt
@@ -29,7 +29,7 @@ data class PlaybackProgressInfo(
 	@SerialName("CanSeek")
 	val canSeek: Boolean,
 	@SerialName("Item")
-	val item: BaseItemDto,
+	val item: BaseItemDto? = null,
 	/**
 	 * Gets or sets the item identifier.
 	 */
@@ -82,7 +82,7 @@ data class PlaybackProgressInfo(
 	@SerialName("AspectRatio")
 	val aspectRatio: String? = null,
 	@SerialName("PlayMethod")
-	val playMethod: PlayMethod,
+	val playMethod: PlayMethod? = null,
 	/**
 	 * Gets or sets the live stream identifier.
 	 */
@@ -94,7 +94,7 @@ data class PlaybackProgressInfo(
 	@SerialName("PlaySessionId")
 	val playSessionId: String? = null,
 	@SerialName("RepeatMode")
-	val repeatMode: RepeatMode,
+	val repeatMode: RepeatMode? = null,
 	@SerialName("NowPlayingQueue")
 	val nowPlayingQueue: List<QueueItem>? = null,
 	@SerialName("PlaylistItemId")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PlaybackStartInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PlaybackStartInfo.kt
@@ -29,7 +29,7 @@ data class PlaybackStartInfo(
 	@SerialName("CanSeek")
 	val canSeek: Boolean,
 	@SerialName("Item")
-	val item: BaseItemDto,
+	val item: BaseItemDto? = null,
 	/**
 	 * Gets or sets the item identifier.
 	 */
@@ -82,7 +82,7 @@ data class PlaybackStartInfo(
 	@SerialName("AspectRatio")
 	val aspectRatio: String? = null,
 	@SerialName("PlayMethod")
-	val playMethod: PlayMethod,
+	val playMethod: PlayMethod? = null,
 	/**
 	 * Gets or sets the live stream identifier.
 	 */
@@ -94,7 +94,7 @@ data class PlaybackStartInfo(
 	@SerialName("PlaySessionId")
 	val playSessionId: String? = null,
 	@SerialName("RepeatMode")
-	val repeatMode: RepeatMode,
+	val repeatMode: RepeatMode? = null,
 	@SerialName("NowPlayingQueue")
 	val nowPlayingQueue: List<QueueItem>? = null,
 	@SerialName("PlaylistItemId")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PlaybackStopInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PlaybackStopInfo.kt
@@ -23,7 +23,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 @Serializable
 data class PlaybackStopInfo(
 	@SerialName("Item")
-	val item: BaseItemDto,
+	val item: BaseItemDto? = null,
 	/**
 	 * Gets or sets the item identifier.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PlayerStateInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PlayerStateInfo.kt
@@ -55,7 +55,7 @@ data class PlayerStateInfo(
 	@SerialName("MediaSourceId")
 	val mediaSourceId: String? = null,
 	@SerialName("PlayMethod")
-	val playMethod: PlayMethod,
+	val playMethod: PlayMethod? = null,
 	@SerialName("RepeatMode")
-	val repeatMode: RepeatMode
+	val repeatMode: RepeatMode? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PlaystateRequest.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/PlaystateRequest.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class PlaystateRequest(
 	@SerialName("Command")
-	val command: PlaystateCommand,
+	val command: PlaystateCommand? = null,
 	@SerialName("SeekPositionTicks")
 	val seekPositionTicks: Long? = null,
 	/**

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ProfileCondition.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ProfileCondition.kt
@@ -13,9 +13,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ProfileCondition(
 	@SerialName("Condition")
-	val condition: ProfileConditionType,
+	val condition: ProfileConditionType? = null,
 	@SerialName("Property")
-	val property: ProfileConditionValue,
+	val property: ProfileConditionValue? = null,
 	@SerialName("Value")
 	val value: String? = null,
 	@SerialName("IsRequired")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/RecommendationDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/RecommendationDto.kt
@@ -20,7 +20,7 @@ data class RecommendationDto(
 	@SerialName("Items")
 	val items: List<BaseItemDto>? = null,
 	@SerialName("RecommendationType")
-	val recommendationType: RecommendationType,
+	val recommendationType: RecommendationType? = null,
 	@SerialName("BaselineItemName")
 	val baselineItemName: String? = null,
 	@SerialName("CategoryId")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/RemoteImageInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/RemoteImageInfo.kt
@@ -57,7 +57,7 @@ data class RemoteImageInfo(
 	@SerialName("Language")
 	val language: String? = null,
 	@SerialName("Type")
-	val type: ImageType,
+	val type: ImageType? = null,
 	@SerialName("RatingType")
-	val ratingType: RatingType
+	val ratingType: RatingType? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/RemoteSearchResult.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/RemoteSearchResult.kt
@@ -49,7 +49,7 @@ data class RemoteSearchResult(
 	@SerialName("Overview")
 	val overview: String? = null,
 	@SerialName("AlbumArtist")
-	val albumArtist: RemoteSearchResult,
+	val albumArtist: RemoteSearchResult? = null,
 	@SerialName("Artists")
 	val artists: List<RemoteSearchResult>? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ResponseProfile.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ResponseProfile.kt
@@ -19,7 +19,7 @@ data class ResponseProfile(
 	@SerialName("VideoCodec")
 	val videoCodec: String? = null,
 	@SerialName("Type")
-	val type: DlnaProfileType,
+	val type: DlnaProfileType? = null,
 	@SerialName("OrgPn")
 	val orgPn: String? = null,
 	@SerialName("MimeType")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/SeriesInfoRemoteSearchQuery.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/SeriesInfoRemoteSearchQuery.kt
@@ -18,7 +18,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 @Serializable
 data class SeriesInfoRemoteSearchQuery(
 	@SerialName("SearchInfo")
-	val searchInfo: SeriesInfo,
+	val searchInfo: SeriesInfo? = null,
 	@SerialName("ItemId")
 	val itemId: UUID,
 	/**

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/SeriesTimerInfoDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/SeriesTimerInfoDto.kt
@@ -53,7 +53,7 @@ data class SeriesTimerInfoDto(
 	@SerialName("Days")
 	val days: List<DayOfWeek>? = null,
 	@SerialName("DayPattern")
-	val dayPattern: DayPattern,
+	val dayPattern: DayPattern? = null,
 	/**
 	 * Gets or sets the image tags.
 	 */
@@ -184,5 +184,5 @@ data class SeriesTimerInfoDto(
 	@SerialName("IsPostPaddingRequired")
 	val isPostPaddingRequired: Boolean,
 	@SerialName("KeepUntil")
-	val keepUntil: KeepUntil
+	val keepUntil: KeepUntil? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ServerConfiguration.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/ServerConfiguration.kt
@@ -155,7 +155,7 @@ data class ServerConfiguration(
 	@SerialName("EnableDashboardResponseCaching")
 	val enableDashboardResponseCaching: Boolean,
 	@SerialName("ImageSavingConvention")
-	val imageSavingConvention: ImageSavingConvention,
+	val imageSavingConvention: ImageSavingConvention? = null,
 	@SerialName("MetadataOptions")
 	val metadataOptions: List<MetadataOptions>? = null,
 	@SerialName("SkipDeserializationForBasicTypes")
@@ -240,7 +240,7 @@ data class ServerConfiguration(
 	@SerialName("CachePath")
 	val cachePath: String? = null,
 	@SerialName("PreviousVersion")
-	val previousVersion: Version,
+	val previousVersion: Version? = null,
 	/**
 	 * Gets or sets the stringified PreviousVersion to be stored/loaded,
 	 * because System.Version itself isn't xml-serializable.

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/SessionInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/SessionInfo.kt
@@ -27,11 +27,11 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 @Serializable
 data class SessionInfo(
 	@SerialName("PlayState")
-	val playState: PlayerStateInfo,
+	val playState: PlayerStateInfo? = null,
 	@SerialName("AdditionalUsers")
 	val additionalUsers: List<SessionUserInfo>? = null,
 	@SerialName("Capabilities")
-	val capabilities: ClientCapabilities,
+	val capabilities: ClientCapabilities? = null,
 	/**
 	 * Gets or sets the remote end point.
 	 */
@@ -83,11 +83,11 @@ data class SessionInfo(
 	@SerialName("DeviceType")
 	val deviceType: String? = null,
 	@SerialName("NowPlayingItem")
-	val nowPlayingItem: BaseItemDto,
+	val nowPlayingItem: BaseItemDto? = null,
 	@SerialName("FullNowPlayingItem")
-	val fullNowPlayingItem: BaseItem,
+	val fullNowPlayingItem: BaseItem? = null,
 	@SerialName("NowViewingItem")
-	val nowViewingItem: BaseItemDto,
+	val nowViewingItem: BaseItemDto? = null,
 	/**
 	 * Gets or sets the device id.
 	 */
@@ -99,7 +99,7 @@ data class SessionInfo(
 	@SerialName("ApplicationVersion")
 	val applicationVersion: String? = null,
 	@SerialName("TranscodingInfo")
-	val transcodingInfo: TranscodingInfo,
+	val transcodingInfo: TranscodingInfo? = null,
 	/**
 	 * Gets a value indicating whether this instance is active.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/SubtitleProfile.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/SubtitleProfile.kt
@@ -14,7 +14,7 @@ data class SubtitleProfile(
 	@SerialName("Format")
 	val format: String? = null,
 	@SerialName("Method")
-	val method: SubtitleDeliveryMethod,
+	val method: SubtitleDeliveryMethod? = null,
 	@SerialName("DidlMode")
 	val didlMode: String? = null,
 	@SerialName("Language")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/SystemInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/SystemInfo.kt
@@ -97,9 +97,9 @@ data class SystemInfo(
 	@SerialName("HasUpdateAvailable")
 	val hasUpdateAvailable: Boolean,
 	@SerialName("EncoderLocation")
-	val encoderLocation: FFmpegLocation,
+	val encoderLocation: FFmpegLocation? = null,
 	@SerialName("SystemArchitecture")
-	val systemArchitecture: Architecture,
+	val systemArchitecture: Architecture? = null,
 	/**
 	 * Gets or sets the local address.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/TaskInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/TaskInfo.kt
@@ -23,7 +23,7 @@ data class TaskInfo(
 	@SerialName("Name")
 	val name: String? = null,
 	@SerialName("State")
-	val state: TaskState,
+	val state: TaskState? = null,
 	/**
 	 * Gets or sets the progress.
 	 */
@@ -35,7 +35,7 @@ data class TaskInfo(
 	@SerialName("Id")
 	val id: String? = null,
 	@SerialName("LastExecutionResult")
-	val lastExecutionResult: TaskResult,
+	val lastExecutionResult: TaskResult? = null,
 	/**
 	 * Gets or sets the triggers.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/TaskResult.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/TaskResult.kt
@@ -30,7 +30,7 @@ data class TaskResult(
 	@SerialName("EndTimeUtc")
 	val endTimeUtc: LocalDateTime,
 	@SerialName("Status")
-	val status: TaskCompletionStatus,
+	val status: TaskCompletionStatus? = null,
 	/**
 	 * Gets or sets the name.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/TaskTriggerInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/TaskTriggerInfo.kt
@@ -31,7 +31,7 @@ data class TaskTriggerInfo(
 	@SerialName("IntervalTicks")
 	val intervalTicks: Long? = null,
 	@SerialName("DayOfWeek")
-	val dayOfWeek: DayOfWeek,
+	val dayOfWeek: DayOfWeek? = null,
 	/**
 	 * Gets or sets the maximum runtime ticks.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/TimerInfoDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/TimerInfoDto.kt
@@ -26,7 +26,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 @Serializable
 data class TimerInfoDto(
 	@SerialName("Status")
-	val status: RecordingStatus,
+	val status: RecordingStatus? = null,
 	/**
 	 * Gets or sets the series timer identifier.
 	 */
@@ -43,7 +43,7 @@ data class TimerInfoDto(
 	@SerialName("RunTimeTicks")
 	val runTimeTicks: Long? = null,
 	@SerialName("ProgramInfo")
-	val programInfo: BaseItemDto,
+	val programInfo: BaseItemDto? = null,
 	/**
 	 * Id of the recording.
 	 */
@@ -149,5 +149,5 @@ data class TimerInfoDto(
 	@SerialName("IsPostPaddingRequired")
 	val isPostPaddingRequired: Boolean,
 	@SerialName("KeepUntil")
-	val keepUntil: KeepUntil
+	val keepUntil: KeepUntil? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/TrailerInfoRemoteSearchQuery.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/TrailerInfoRemoteSearchQuery.kt
@@ -18,7 +18,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 @Serializable
 data class TrailerInfoRemoteSearchQuery(
 	@SerialName("SearchInfo")
-	val searchInfo: TrailerInfo,
+	val searchInfo: TrailerInfo? = null,
 	@SerialName("ItemId")
 	val itemId: UUID,
 	/**

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/TranscodingProfile.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/TranscodingProfile.kt
@@ -16,7 +16,7 @@ data class TranscodingProfile(
 	@SerialName("Container")
 	val container: String? = null,
 	@SerialName("Type")
-	val type: DlnaProfileType,
+	val type: DlnaProfileType? = null,
 	@SerialName("VideoCodec")
 	val videoCodec: String? = null,
 	@SerialName("AudioCodec")
@@ -28,11 +28,11 @@ data class TranscodingProfile(
 	@SerialName("EnableMpegtsM2TsMode")
 	val enableMpegtsM2TsMode: Boolean,
 	@SerialName("TranscodeSeekInfo")
-	val transcodeSeekInfo: TranscodeSeekInfo,
+	val transcodeSeekInfo: TranscodeSeekInfo? = null,
 	@SerialName("CopyTimestamps")
 	val copyTimestamps: Boolean,
 	@SerialName("Context")
-	val context: EncodingContext,
+	val context: EncodingContext? = null,
 	@SerialName("EnableSubtitlesInManifest")
 	val enableSubtitlesInManifest: Boolean,
 	@SerialName("MaxAudioChannels")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/UpdateLibraryOptionsDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/UpdateLibraryOptionsDto.kt
@@ -24,5 +24,5 @@ data class UpdateLibraryOptionsDto(
 	@SerialName("Id")
 	val id: UUID,
 	@SerialName("LibraryOptions")
-	val libraryOptions: LibraryOptions
+	val libraryOptions: LibraryOptions? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/UserConfiguration.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/UserConfiguration.kt
@@ -36,7 +36,7 @@ data class UserConfiguration(
 	@SerialName("GroupedFolders")
 	val groupedFolders: List<String>? = null,
 	@SerialName("SubtitleMode")
-	val subtitleMode: SubtitlePlaybackMode,
+	val subtitleMode: SubtitlePlaybackMode? = null,
 	@SerialName("DisplayCollectionsView")
 	val displayCollectionsView: Boolean,
 	@SerialName("EnableLocalPassword")

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/UserDto.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/UserDto.kt
@@ -83,9 +83,9 @@ data class UserDto(
 	@SerialName("LastActivityDate")
 	val lastActivityDate: LocalDateTime? = null,
 	@SerialName("Configuration")
-	val configuration: UserConfiguration,
+	val configuration: UserConfiguration? = null,
 	@SerialName("Policy")
-	val policy: UserPolicy,
+	val policy: UserPolicy? = null,
 	/**
 	 * Gets or sets the primary image aspect ratio.
 	 */

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/UserPolicy.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/UserPolicy.kt
@@ -109,5 +109,5 @@ data class UserPolicy(
 	@SerialName("PasswordResetProviderId")
 	val passwordResetProviderId: String? = null,
 	@SerialName("SyncPlayAccess")
-	val syncPlayAccess: SyncPlayAccess
+	val syncPlayAccess: SyncPlayAccess? = null
 )

--- a/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/VirtualFolderInfo.kt
+++ b/model/src/main/kotlin-generated/org/jellyfin/apiclient/model/api/VirtualFolderInfo.kt
@@ -32,7 +32,7 @@ data class VirtualFolderInfo(
 	@SerialName("CollectionType")
 	val collectionType: String? = null,
 	@SerialName("LibraryOptions")
-	val libraryOptions: LibraryOptions,
+	val libraryOptions: LibraryOptions? = null,
 	/**
 	 * Gets or sets the item identifier.
 	 */

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/HooksModule.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/HooksModule.kt
@@ -1,8 +1,11 @@
 package org.jellyfin.openapi.hooks
 
 import org.jellyfin.openapi.hooks.model.ImageMapsHook
+import org.jellyfin.openapi.hooks.model.NullableReferencesHook
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val hooksModule = module {
-	single<TypeBuilderHook> { ImageMapsHook() }
+	single { ImageMapsHook() } bind TypeBuilderHook::class
+	single { NullableReferencesHook() } bind TypeBuilderHook::class
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/TypeBuilderHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/TypeBuilderHook.kt
@@ -2,10 +2,11 @@ package org.jellyfin.openapi.hooks
 
 import com.squareup.kotlinpoet.TypeName
 import io.swagger.v3.oas.models.media.Schema
+import org.jellyfin.openapi.builder.openapi.OpenApiTypeBuilder
 
 interface TypeBuilderHook {
 	/**
 	 * Try to create an type or return null if not applicable for this hook.
 	 */
-	fun onBuildType(path: TypePath, schema: Schema<*>): TypeName?
+	fun onBuildType(path: TypePath, schema: Schema<*>, typeBuilder: OpenApiTypeBuilder): TypeName?
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/ImageMapsHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/ImageMapsHook.kt
@@ -4,6 +4,7 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.plusParameter
 import com.squareup.kotlinpoet.asTypeName
 import io.swagger.v3.oas.models.media.Schema
+import org.jellyfin.openapi.builder.openapi.OpenApiTypeBuilder
 import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.hooks.ModelTypePath
 import org.jellyfin.openapi.hooks.TypeBuilderHook
@@ -14,7 +15,7 @@ import org.jellyfin.openapi.hooks.TypePath
  * The map uses the type Map<ImageType, String> for images and Map<ImageType, Map<String, String>> for blurhashes
  */
 class ImageMapsHook : TypeBuilderHook {
-	override fun onBuildType(path: TypePath, schema: Schema<*>) = when (path) {
+	override fun onBuildType(path: TypePath, schema: Schema<*>, typeBuilder: OpenApiTypeBuilder) = when (path) {
 		ModelTypePath("BaseItemDto", "imageTags") -> buildImageTags()
 		ModelTypePath("BaseItemDto", "imageBlurHashes") -> buildImageBlurHashes()
 		ModelTypePath("BaseItemPerson", "imageBlurHashes") -> buildImageBlurHashes()

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/NullableReferencesHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/NullableReferencesHook.kt
@@ -1,0 +1,22 @@
+package org.jellyfin.openapi.hooks.model
+
+import com.squareup.kotlinpoet.TypeName
+import io.swagger.v3.oas.models.media.Schema
+import org.jellyfin.openapi.builder.openapi.OpenApiTypeBuilder
+import org.jellyfin.openapi.hooks.ModelTypePath
+import org.jellyfin.openapi.hooks.TypeBuilderHook
+import org.jellyfin.openapi.hooks.TypePath
+
+/**
+ * A hook that makes references to objects in models nullable as workaround for the missing
+ * nullable properties in the OpenAPI document.
+ */
+class NullableReferencesHook : TypeBuilderHook {
+	override fun onBuildType(path: TypePath, schema: Schema<*>, typeBuilder: OpenApiTypeBuilder): TypeName? {
+		if (path !is ModelTypePath) return null
+		if (schema.`$ref` == null) return null
+
+		val type = typeBuilder.buildSchema(schema)
+		return type.copy(nullable = true)
+	}
+}


### PR DESCRIPTION
This PR adds a hook that makes references to objects in models nullable as workaround for the missing nullable properties in the OpenAPI document.

Ideally this should be fixed in server but with this workaround I can continue developing the apiclient for now.