### PR TITLE
Add operation url function to API services

### DIFF
--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/AudioApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/AudioApi.kt
@@ -266,6 +266,179 @@ class AudioApi(
 	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
 	 * @param streamOptions Optional. The streaming options.
 	 */
+	fun getAudioStreamUrl(
+		itemId: UUID,
+		container: String,
+		static: Boolean? = null,
+		params: String? = null,
+		tag: String? = null,
+		deviceProfileId: String? = null,
+		playSessionId: String? = null,
+		segmentContainer: String? = null,
+		segmentLength: Int? = null,
+		minSegments: Int? = null,
+		mediaSourceId: String? = null,
+		deviceId: String? = null,
+		audioCodec: String? = null,
+		enableAutoStreamCopy: Boolean? = null,
+		allowVideoStreamCopy: Boolean? = null,
+		allowAudioStreamCopy: Boolean? = null,
+		breakOnNonKeyFrames: Boolean? = null,
+		audioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		audioBitRate: Int? = null,
+		audioChannels: Int? = null,
+		maxAudioChannels: Int? = null,
+		profile: String? = null,
+		level: String? = null,
+		framerate: Float? = null,
+		maxFramerate: Float? = null,
+		copyTimestamps: Boolean? = null,
+		startTimeTicks: Long? = null,
+		width: Int? = null,
+		height: Int? = null,
+		videoBitRate: Int? = null,
+		subtitleStreamIndex: Int? = null,
+		subtitleMethod: SubtitleDeliveryMethod,
+		maxRefFrames: Int? = null,
+		maxVideoBitDepth: Int? = null,
+		requireAvc: Boolean? = null,
+		deInterlace: Boolean? = null,
+		requireNonAnamorphic: Boolean? = null,
+		transcodingMaxAudioChannels: Int? = null,
+		cpuCoreLimit: Int? = null,
+		liveStreamId: String? = null,
+		enableMpegtsM2TsMode: Boolean? = null,
+		videoCodec: String? = null,
+		subtitleCodec: String? = null,
+		transcodingReasons: String? = null,
+		audioStreamIndex: Int? = null,
+		videoStreamIndex: Int? = null,
+		context: EncodingContext,
+		streamOptions: Map<String, String>? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["container"] = container
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["static"] = static
+		queryParameters["params"] = params
+		queryParameters["tag"] = tag
+		queryParameters["deviceProfileId"] = deviceProfileId
+		queryParameters["playSessionId"] = playSessionId
+		queryParameters["segmentContainer"] = segmentContainer
+		queryParameters["segmentLength"] = segmentLength
+		queryParameters["minSegments"] = minSegments
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
+		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
+		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["audioSampleRate"] = audioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["audioBitRate"] = audioBitRate
+		queryParameters["audioChannels"] = audioChannels
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["profile"] = profile
+		queryParameters["level"] = level
+		queryParameters["framerate"] = framerate
+		queryParameters["maxFramerate"] = maxFramerate
+		queryParameters["copyTimestamps"] = copyTimestamps
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["videoBitRate"] = videoBitRate
+		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
+		queryParameters["subtitleMethod"] = subtitleMethod
+		queryParameters["maxRefFrames"] = maxRefFrames
+		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
+		queryParameters["requireAvc"] = requireAvc
+		queryParameters["deInterlace"] = deInterlace
+		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
+		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
+		queryParameters["cpuCoreLimit"] = cpuCoreLimit
+		queryParameters["liveStreamId"] = liveStreamId
+		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
+		queryParameters["videoCodec"] = videoCodec
+		queryParameters["subtitleCodec"] = subtitleCodec
+		queryParameters["transcodingReasons"] = transcodingReasons
+		queryParameters["audioStreamIndex"] = audioStreamIndex
+		queryParameters["videoStreamIndex"] = videoStreamIndex
+		queryParameters["context"] = context
+		queryParameters["streamOptions"] = streamOptions
+		return api.createUrl("/Audio/{itemId}/stream", pathParameters, queryParameters)
+	}
+
+	/**
+	 * Gets an audio stream.
+	 *
+	 * @param itemId The item id.
+	 * @param container The audio container.
+	 * @param static Optional. If true, the original file will be streamed statically without any
+	 * encoding. Use either no url extension or the original file extension. true/false.
+	 * @param params The streaming parameters.
+	 * @param tag The tag.
+	 * @param deviceProfileId Optional. The dlna device profile id to utilize.
+	 * @param playSessionId The play session id.
+	 * @param segmentContainer The segment container.
+	 * @param segmentLength The segment lenght.
+	 * @param minSegments The minimum number of segments.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param audioCodec Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server
+	 * will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.
+	 * @param enableAutoStreamCopy Whether or not to allow automatic stream copy if requested values
+	 * match the original source. Defaults to true.
+	 * @param allowVideoStreamCopy Whether or not to allow copying of the video stream url.
+	 * @param allowAudioStreamCopy Whether or not to allow copying of the audio stream url.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param audioSampleRate Optional. Specify a specific audio sample rate, e.g. 44100.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param audioBitRate Optional. Specify an audio bitrate to encode to, e.g. 128000. If omitted
+	 * this will be left to encoder defaults.
+	 * @param audioChannels Optional. Specify a specific number of audio channels to encode to, e.g. 2.
+	 * @param maxAudioChannels Optional. Specify a maximum number of audio channels to encode to, e.g.
+	 * 2.
+	 * @param profile Optional. Specify a specific an encoder profile (varies by encoder), e.g. main,
+	 * baseline, high.
+	 * @param level Optional. Specify a level for the encoder profile (varies by encoder), e.g. 3, 3.1.
+	 * @param framerate Optional. A specific video framerate to encode to, e.g. 23.976. Generally this
+	 * should be omitted unless the device has specific requirements.
+	 * @param maxFramerate Optional. A specific maximum video framerate to encode to, e.g. 23.976.
+	 * Generally this should be omitted unless the device has specific requirements.
+	 * @param copyTimestamps Whether or not to copy timestamps when transcoding with an offset.
+	 * Defaults to false.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param width Optional. The fixed horizontal resolution of the encoded video.
+	 * @param height Optional. The fixed vertical resolution of the encoded video.
+	 * @param videoBitRate Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this
+	 * will be left to encoder defaults.
+	 * @param subtitleStreamIndex Optional. The index of the subtitle stream to use. If omitted no
+	 * subtitles will be used.
+	 * @param subtitleMethod Optional. Specify the subtitle delivery method.
+	 * @param maxRefFrames Optional.
+	 * @param maxVideoBitDepth Optional. The maximum video bit depth.
+	 * @param requireAvc Optional. Whether to require avc.
+	 * @param deInterlace Optional. Whether to deinterlace the video.
+	 * @param requireNonAnamorphic Optional. Whether to require a non anamporphic stream.
+	 * @param transcodingMaxAudioChannels Optional. The maximum number of audio channels to transcode.
+	 * @param cpuCoreLimit Optional. The limit of how many cpu cores to use.
+	 * @param liveStreamId The live stream id.
+	 * @param enableMpegtsM2TsMode Optional. Whether to enable the MpegtsM2Ts mode.
+	 * @param videoCodec Optional. Specify a video codec to encode to, e.g. h264. If omitted the server
+	 * will auto-select using the url's extension. Options: h265, h264, mpeg4, theora, vpx, wmv.
+	 * @param subtitleCodec Optional. Specify a subtitle codec to encode to.
+	 * @param transcodingReasons Optional. The transcoding reason.
+	 * @param audioStreamIndex Optional. The index of the audio stream to use. If omitted the first
+	 * audio stream will be used.
+	 * @param videoStreamIndex Optional. The index of the video stream to use. If omitted the first
+	 * video stream will be used.
+	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
+	 * @param streamOptions Optional. The streaming options.
+	 */
 	suspend fun getAudioStreamByContainer(
 		itemId: UUID,
 		container: String,
@@ -372,5 +545,178 @@ class AudioApi(
 		val response = api.get<InputStream>("/Audio/{itemId}/stream.{container}", pathParameters,
 				queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Gets an audio stream.
+	 *
+	 * @param itemId The item id.
+	 * @param container The audio container.
+	 * @param static Optional. If true, the original file will be streamed statically without any
+	 * encoding. Use either no url extension or the original file extension. true/false.
+	 * @param params The streaming parameters.
+	 * @param tag The tag.
+	 * @param deviceProfileId Optional. The dlna device profile id to utilize.
+	 * @param playSessionId The play session id.
+	 * @param segmentContainer The segment container.
+	 * @param segmentLength The segment lenght.
+	 * @param minSegments The minimum number of segments.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param audioCodec Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server
+	 * will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.
+	 * @param enableAutoStreamCopy Whether or not to allow automatic stream copy if requested values
+	 * match the original source. Defaults to true.
+	 * @param allowVideoStreamCopy Whether or not to allow copying of the video stream url.
+	 * @param allowAudioStreamCopy Whether or not to allow copying of the audio stream url.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param audioSampleRate Optional. Specify a specific audio sample rate, e.g. 44100.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param audioBitRate Optional. Specify an audio bitrate to encode to, e.g. 128000. If omitted
+	 * this will be left to encoder defaults.
+	 * @param audioChannels Optional. Specify a specific number of audio channels to encode to, e.g. 2.
+	 * @param maxAudioChannels Optional. Specify a maximum number of audio channels to encode to, e.g.
+	 * 2.
+	 * @param profile Optional. Specify a specific an encoder profile (varies by encoder), e.g. main,
+	 * baseline, high.
+	 * @param level Optional. Specify a level for the encoder profile (varies by encoder), e.g. 3, 3.1.
+	 * @param framerate Optional. A specific video framerate to encode to, e.g. 23.976. Generally this
+	 * should be omitted unless the device has specific requirements.
+	 * @param maxFramerate Optional. A specific maximum video framerate to encode to, e.g. 23.976.
+	 * Generally this should be omitted unless the device has specific requirements.
+	 * @param copyTimestamps Whether or not to copy timestamps when transcoding with an offset.
+	 * Defaults to false.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param width Optional. The fixed horizontal resolution of the encoded video.
+	 * @param height Optional. The fixed vertical resolution of the encoded video.
+	 * @param videoBitRate Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this
+	 * will be left to encoder defaults.
+	 * @param subtitleStreamIndex Optional. The index of the subtitle stream to use. If omitted no
+	 * subtitles will be used.
+	 * @param subtitleMethod Optional. Specify the subtitle delivery method.
+	 * @param maxRefFrames Optional.
+	 * @param maxVideoBitDepth Optional. The maximum video bit depth.
+	 * @param requireAvc Optional. Whether to require avc.
+	 * @param deInterlace Optional. Whether to deinterlace the video.
+	 * @param requireNonAnamorphic Optional. Whether to require a non anamporphic stream.
+	 * @param transcodingMaxAudioChannels Optional. The maximum number of audio channels to transcode.
+	 * @param cpuCoreLimit Optional. The limit of how many cpu cores to use.
+	 * @param liveStreamId The live stream id.
+	 * @param enableMpegtsM2TsMode Optional. Whether to enable the MpegtsM2Ts mode.
+	 * @param videoCodec Optional. Specify a video codec to encode to, e.g. h264. If omitted the server
+	 * will auto-select using the url's extension. Options: h265, h264, mpeg4, theora, vpx, wmv.
+	 * @param subtitleCodec Optional. Specify a subtitle codec to encode to.
+	 * @param transcodingReasons Optional. The transcoding reason.
+	 * @param audioStreamIndex Optional. The index of the audio stream to use. If omitted the first
+	 * audio stream will be used.
+	 * @param videoStreamIndex Optional. The index of the video stream to use. If omitted the first
+	 * video stream will be used.
+	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
+	 * @param streamOptions Optional. The streaming options.
+	 */
+	fun getAudioStreamByContainerUrl(
+		itemId: UUID,
+		container: String,
+		static: Boolean? = null,
+		params: String? = null,
+		tag: String? = null,
+		deviceProfileId: String? = null,
+		playSessionId: String? = null,
+		segmentContainer: String? = null,
+		segmentLength: Int? = null,
+		minSegments: Int? = null,
+		mediaSourceId: String? = null,
+		deviceId: String? = null,
+		audioCodec: String? = null,
+		enableAutoStreamCopy: Boolean? = null,
+		allowVideoStreamCopy: Boolean? = null,
+		allowAudioStreamCopy: Boolean? = null,
+		breakOnNonKeyFrames: Boolean? = null,
+		audioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		audioBitRate: Int? = null,
+		audioChannels: Int? = null,
+		maxAudioChannels: Int? = null,
+		profile: String? = null,
+		level: String? = null,
+		framerate: Float? = null,
+		maxFramerate: Float? = null,
+		copyTimestamps: Boolean? = null,
+		startTimeTicks: Long? = null,
+		width: Int? = null,
+		height: Int? = null,
+		videoBitRate: Int? = null,
+		subtitleStreamIndex: Int? = null,
+		subtitleMethod: SubtitleDeliveryMethod,
+		maxRefFrames: Int? = null,
+		maxVideoBitDepth: Int? = null,
+		requireAvc: Boolean? = null,
+		deInterlace: Boolean? = null,
+		requireNonAnamorphic: Boolean? = null,
+		transcodingMaxAudioChannels: Int? = null,
+		cpuCoreLimit: Int? = null,
+		liveStreamId: String? = null,
+		enableMpegtsM2TsMode: Boolean? = null,
+		videoCodec: String? = null,
+		subtitleCodec: String? = null,
+		transcodingReasons: String? = null,
+		audioStreamIndex: Int? = null,
+		videoStreamIndex: Int? = null,
+		context: EncodingContext,
+		streamOptions: Map<String, String>? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["container"] = container
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["static"] = static
+		queryParameters["params"] = params
+		queryParameters["tag"] = tag
+		queryParameters["deviceProfileId"] = deviceProfileId
+		queryParameters["playSessionId"] = playSessionId
+		queryParameters["segmentContainer"] = segmentContainer
+		queryParameters["segmentLength"] = segmentLength
+		queryParameters["minSegments"] = minSegments
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
+		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
+		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["audioSampleRate"] = audioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["audioBitRate"] = audioBitRate
+		queryParameters["audioChannels"] = audioChannels
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["profile"] = profile
+		queryParameters["level"] = level
+		queryParameters["framerate"] = framerate
+		queryParameters["maxFramerate"] = maxFramerate
+		queryParameters["copyTimestamps"] = copyTimestamps
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["videoBitRate"] = videoBitRate
+		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
+		queryParameters["subtitleMethod"] = subtitleMethod
+		queryParameters["maxRefFrames"] = maxRefFrames
+		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
+		queryParameters["requireAvc"] = requireAvc
+		queryParameters["deInterlace"] = deInterlace
+		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
+		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
+		queryParameters["cpuCoreLimit"] = cpuCoreLimit
+		queryParameters["liveStreamId"] = liveStreamId
+		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
+		queryParameters["videoCodec"] = videoCodec
+		queryParameters["subtitleCodec"] = subtitleCodec
+		queryParameters["transcodingReasons"] = transcodingReasons
+		queryParameters["audioStreamIndex"] = audioStreamIndex
+		queryParameters["videoStreamIndex"] = videoStreamIndex
+		queryParameters["context"] = context
+		queryParameters["streamOptions"] = streamOptions
+		return api.createUrl("/Audio/{itemId}/stream.{container}", pathParameters, queryParameters)
 	}
 }

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ConfigurationApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ConfigurationApi.kt
@@ -56,6 +56,18 @@ class ConfigurationApi(
 	}
 
 	/**
+	 * Gets a named configuration.
+	 *
+	 * @param key Configuration key.
+	 */
+	fun getNamedConfigurationUrl(key: String): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["key"] = key
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/System/Configuration/{key}", pathParameters, queryParameters)
+	}
+
+	/**
 	 * Updates named configuration.
 	 *
 	 * @param key Configuration key.

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/DlnaServerApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/DlnaServerApi.kt
@@ -183,6 +183,20 @@ class DlnaServerApi(
 	}
 
 	/**
+	 * Gets a server icon.
+	 *
+	 * @param serverId Server UUID.
+	 * @param fileName The icon filename.
+	 */
+	fun getIconIdUrl(serverId: String, fileName: String): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["serverId"] = serverId
+		pathParameters["fileName"] = fileName
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/Dlna/{serverId}/icons/{fileName}", pathParameters, queryParameters)
+	}
+
+	/**
 	 * Gets Dlna media receiver registrar xml.
 	 *
 	 * @param serverId Server UUID.
@@ -257,5 +271,17 @@ class DlnaServerApi(
 		val response = api.get<InputStream>("/Dlna/icons/{fileName}", pathParameters, queryParameters,
 				data)
 		return response
+	}
+
+	/**
+	 * Gets a server icon.
+	 *
+	 * @param fileName The icon filename.
+	 */
+	fun getIconUrl(fileName: String): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["fileName"] = fileName
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/Dlna/icons/{fileName}", pathParameters, queryParameters)
 	}
 }

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/DynamicHlsApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/DynamicHlsApi.kt
@@ -206,6 +206,187 @@ class DynamicHlsApi(
 	}
 
 	/**
+	 * Gets a video stream using HTTP live streaming.
+	 *
+	 * @param itemId The item id.
+	 * @param playlistId The playlist id.
+	 * @param segmentId The segment id.
+	 * @param container The video container. Possible values are: ts, webm, asf, wmv, ogv, mp4, m4v,
+	 * mkv, mpeg, mpg, avi, 3gp, wmv, wtv, m2ts, mov, iso, flv.
+	 * @param static Optional. If true, the original file will be streamed statically without any
+	 * encoding. Use either no url extension or the original file extension. true/false.
+	 * @param params The streaming parameters.
+	 * @param tag The tag.
+	 * @param deviceProfileId Optional. The dlna device profile id to utilize.
+	 * @param playSessionId The play session id.
+	 * @param segmentContainer The segment container.
+	 * @param segmentLength The segment lenght.
+	 * @param minSegments The minimum number of segments.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param audioCodec Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server
+	 * will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.
+	 * @param enableAutoStreamCopy Whether or not to allow automatic stream copy if requested values
+	 * match the original source. Defaults to true.
+	 * @param allowVideoStreamCopy Whether or not to allow copying of the video stream url.
+	 * @param allowAudioStreamCopy Whether or not to allow copying of the audio stream url.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param audioSampleRate Optional. Specify a specific audio sample rate, e.g. 44100.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param audioBitRate Optional. Specify an audio bitrate to encode to, e.g. 128000. If omitted
+	 * this will be left to encoder defaults.
+	 * @param audioChannels Optional. Specify a specific number of audio channels to encode to, e.g. 2.
+	 * @param maxAudioChannels Optional. Specify a maximum number of audio channels to encode to, e.g.
+	 * 2.
+	 * @param profile Optional. Specify a specific an encoder profile (varies by encoder), e.g. main,
+	 * baseline, high.
+	 * @param level Optional. Specify a level for the encoder profile (varies by encoder), e.g. 3, 3.1.
+	 * @param framerate Optional. A specific video framerate to encode to, e.g. 23.976. Generally this
+	 * should be omitted unless the device has specific requirements.
+	 * @param maxFramerate Optional. A specific maximum video framerate to encode to, e.g. 23.976.
+	 * Generally this should be omitted unless the device has specific requirements.
+	 * @param copyTimestamps Whether or not to copy timestamps when transcoding with an offset.
+	 * Defaults to false.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param width Optional. The fixed horizontal resolution of the encoded video.
+	 * @param height Optional. The fixed vertical resolution of the encoded video.
+	 * @param videoBitRate Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this
+	 * will be left to encoder defaults.
+	 * @param subtitleStreamIndex Optional. The index of the subtitle stream to use. If omitted no
+	 * subtitles will be used.
+	 * @param subtitleMethod Optional. Specify the subtitle delivery method.
+	 * @param maxRefFrames Optional.
+	 * @param maxVideoBitDepth Optional. The maximum video bit depth.
+	 * @param requireAvc Optional. Whether to require avc.
+	 * @param deInterlace Optional. Whether to deinterlace the video.
+	 * @param requireNonAnamorphic Optional. Whether to require a non anamporphic stream.
+	 * @param transcodingMaxAudioChannels Optional. The maximum number of audio channels to transcode.
+	 * @param cpuCoreLimit Optional. The limit of how many cpu cores to use.
+	 * @param liveStreamId The live stream id.
+	 * @param enableMpegtsM2TsMode Optional. Whether to enable the MpegtsM2Ts mode.
+	 * @param videoCodec Optional. Specify a video codec to encode to, e.g. h264. If omitted the server
+	 * will auto-select using the url's extension. Options: h265, h264, mpeg4, theora, vpx, wmv.
+	 * @param subtitleCodec Optional. Specify a subtitle codec to encode to.
+	 * @param transcodingReasons Optional. The transcoding reason.
+	 * @param audioStreamIndex Optional. The index of the audio stream to use. If omitted the first
+	 * audio stream will be used.
+	 * @param videoStreamIndex Optional. The index of the video stream to use. If omitted the first
+	 * video stream will be used.
+	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
+	 * @param streamOptions Optional. The streaming options.
+	 */
+	fun getHlsAudioSegmentUrl(
+		itemId: UUID,
+		playlistId: String,
+		segmentId: Int,
+		container: String,
+		static: Boolean? = null,
+		params: String? = null,
+		tag: String? = null,
+		deviceProfileId: String? = null,
+		playSessionId: String? = null,
+		segmentContainer: String? = null,
+		segmentLength: Int? = null,
+		minSegments: Int? = null,
+		mediaSourceId: String? = null,
+		deviceId: String? = null,
+		audioCodec: String? = null,
+		enableAutoStreamCopy: Boolean? = null,
+		allowVideoStreamCopy: Boolean? = null,
+		allowAudioStreamCopy: Boolean? = null,
+		breakOnNonKeyFrames: Boolean? = null,
+		audioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		audioBitRate: Int? = null,
+		audioChannels: Int? = null,
+		maxAudioChannels: Int? = null,
+		profile: String? = null,
+		level: String? = null,
+		framerate: Float? = null,
+		maxFramerate: Float? = null,
+		copyTimestamps: Boolean? = null,
+		startTimeTicks: Long? = null,
+		width: Int? = null,
+		height: Int? = null,
+		videoBitRate: Int? = null,
+		subtitleStreamIndex: Int? = null,
+		subtitleMethod: SubtitleDeliveryMethod,
+		maxRefFrames: Int? = null,
+		maxVideoBitDepth: Int? = null,
+		requireAvc: Boolean? = null,
+		deInterlace: Boolean? = null,
+		requireNonAnamorphic: Boolean? = null,
+		transcodingMaxAudioChannels: Int? = null,
+		cpuCoreLimit: Int? = null,
+		liveStreamId: String? = null,
+		enableMpegtsM2TsMode: Boolean? = null,
+		videoCodec: String? = null,
+		subtitleCodec: String? = null,
+		transcodingReasons: String? = null,
+		audioStreamIndex: Int? = null,
+		videoStreamIndex: Int? = null,
+		context: EncodingContext,
+		streamOptions: Map<String, String>? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["playlistId"] = playlistId
+		pathParameters["segmentId"] = segmentId
+		pathParameters["container"] = container
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["static"] = static
+		queryParameters["params"] = params
+		queryParameters["tag"] = tag
+		queryParameters["deviceProfileId"] = deviceProfileId
+		queryParameters["playSessionId"] = playSessionId
+		queryParameters["segmentContainer"] = segmentContainer
+		queryParameters["segmentLength"] = segmentLength
+		queryParameters["minSegments"] = minSegments
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
+		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
+		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["audioSampleRate"] = audioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["audioBitRate"] = audioBitRate
+		queryParameters["audioChannels"] = audioChannels
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["profile"] = profile
+		queryParameters["level"] = level
+		queryParameters["framerate"] = framerate
+		queryParameters["maxFramerate"] = maxFramerate
+		queryParameters["copyTimestamps"] = copyTimestamps
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["videoBitRate"] = videoBitRate
+		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
+		queryParameters["subtitleMethod"] = subtitleMethod
+		queryParameters["maxRefFrames"] = maxRefFrames
+		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
+		queryParameters["requireAvc"] = requireAvc
+		queryParameters["deInterlace"] = deInterlace
+		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
+		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
+		queryParameters["cpuCoreLimit"] = cpuCoreLimit
+		queryParameters["liveStreamId"] = liveStreamId
+		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
+		queryParameters["videoCodec"] = videoCodec
+		queryParameters["subtitleCodec"] = subtitleCodec
+		queryParameters["transcodingReasons"] = transcodingReasons
+		queryParameters["audioStreamIndex"] = audioStreamIndex
+		queryParameters["videoStreamIndex"] = videoStreamIndex
+		queryParameters["context"] = context
+		queryParameters["streamOptions"] = streamOptions
+		return api.createUrl("/Audio/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters,
+				queryParameters)
+	}
+
+	/**
 	 * Gets an audio stream using HTTP live streaming.
 	 *
 	 * @param itemId The item id.
@@ -380,6 +561,180 @@ class DynamicHlsApi(
 		val response = api.get<InputStream>("/Audio/{itemId}/main.m3u8", pathParameters, queryParameters,
 				data)
 		return response
+	}
+
+	/**
+	 * Gets an audio stream using HTTP live streaming.
+	 *
+	 * @param itemId The item id.
+	 * @param container The video container. Possible values are: ts, webm, asf, wmv, ogv, mp4, m4v,
+	 * mkv, mpeg, mpg, avi, 3gp, wmv, wtv, m2ts, mov, iso, flv.
+	 * @param static Optional. If true, the original file will be streamed statically without any
+	 * encoding. Use either no url extension or the original file extension. true/false.
+	 * @param params The streaming parameters.
+	 * @param tag The tag.
+	 * @param deviceProfileId Optional. The dlna device profile id to utilize.
+	 * @param playSessionId The play session id.
+	 * @param segmentContainer The segment container.
+	 * @param segmentLength The segment lenght.
+	 * @param minSegments The minimum number of segments.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param audioCodec Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server
+	 * will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.
+	 * @param enableAutoStreamCopy Whether or not to allow automatic stream copy if requested values
+	 * match the original source. Defaults to true.
+	 * @param allowVideoStreamCopy Whether or not to allow copying of the video stream url.
+	 * @param allowAudioStreamCopy Whether or not to allow copying of the audio stream url.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param audioSampleRate Optional. Specify a specific audio sample rate, e.g. 44100.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param audioBitRate Optional. Specify an audio bitrate to encode to, e.g. 128000. If omitted
+	 * this will be left to encoder defaults.
+	 * @param audioChannels Optional. Specify a specific number of audio channels to encode to, e.g. 2.
+	 * @param maxAudioChannels Optional. Specify a maximum number of audio channels to encode to, e.g.
+	 * 2.
+	 * @param profile Optional. Specify a specific an encoder profile (varies by encoder), e.g. main,
+	 * baseline, high.
+	 * @param level Optional. Specify a level for the encoder profile (varies by encoder), e.g. 3, 3.1.
+	 * @param framerate Optional. A specific video framerate to encode to, e.g. 23.976. Generally this
+	 * should be omitted unless the device has specific requirements.
+	 * @param maxFramerate Optional. A specific maximum video framerate to encode to, e.g. 23.976.
+	 * Generally this should be omitted unless the device has specific requirements.
+	 * @param copyTimestamps Whether or not to copy timestamps when transcoding with an offset.
+	 * Defaults to false.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param width Optional. The fixed horizontal resolution of the encoded video.
+	 * @param height Optional. The fixed vertical resolution of the encoded video.
+	 * @param videoBitRate Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this
+	 * will be left to encoder defaults.
+	 * @param subtitleStreamIndex Optional. The index of the subtitle stream to use. If omitted no
+	 * subtitles will be used.
+	 * @param subtitleMethod Optional. Specify the subtitle delivery method.
+	 * @param maxRefFrames Optional.
+	 * @param maxVideoBitDepth Optional. The maximum video bit depth.
+	 * @param requireAvc Optional. Whether to require avc.
+	 * @param deInterlace Optional. Whether to deinterlace the video.
+	 * @param requireNonAnamorphic Optional. Whether to require a non anamporphic stream.
+	 * @param transcodingMaxAudioChannels Optional. The maximum number of audio channels to transcode.
+	 * @param cpuCoreLimit Optional. The limit of how many cpu cores to use.
+	 * @param liveStreamId The live stream id.
+	 * @param enableMpegtsM2TsMode Optional. Whether to enable the MpegtsM2Ts mode.
+	 * @param videoCodec Optional. Specify a video codec to encode to, e.g. h264. If omitted the server
+	 * will auto-select using the url's extension. Options: h265, h264, mpeg4, theora, vpx, wmv.
+	 * @param subtitleCodec Optional. Specify a subtitle codec to encode to.
+	 * @param transcodingReasons Optional. The transcoding reason.
+	 * @param audioStreamIndex Optional. The index of the audio stream to use. If omitted the first
+	 * audio stream will be used.
+	 * @param videoStreamIndex Optional. The index of the video stream to use. If omitted the first
+	 * video stream will be used.
+	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
+	 * @param streamOptions Optional. The streaming options.
+	 */
+	fun getVariantHlsAudioPlaylistUrl(
+		itemId: UUID,
+		container: String,
+		static: Boolean? = null,
+		params: String? = null,
+		tag: String? = null,
+		deviceProfileId: String? = null,
+		playSessionId: String? = null,
+		segmentContainer: String? = null,
+		segmentLength: Int? = null,
+		minSegments: Int? = null,
+		mediaSourceId: String? = null,
+		deviceId: String? = null,
+		audioCodec: String? = null,
+		enableAutoStreamCopy: Boolean? = null,
+		allowVideoStreamCopy: Boolean? = null,
+		allowAudioStreamCopy: Boolean? = null,
+		breakOnNonKeyFrames: Boolean? = null,
+		audioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		audioBitRate: Int? = null,
+		audioChannels: Int? = null,
+		maxAudioChannels: Int? = null,
+		profile: String? = null,
+		level: String? = null,
+		framerate: Float? = null,
+		maxFramerate: Float? = null,
+		copyTimestamps: Boolean? = null,
+		startTimeTicks: Long? = null,
+		width: Int? = null,
+		height: Int? = null,
+		videoBitRate: Int? = null,
+		subtitleStreamIndex: Int? = null,
+		subtitleMethod: SubtitleDeliveryMethod,
+		maxRefFrames: Int? = null,
+		maxVideoBitDepth: Int? = null,
+		requireAvc: Boolean? = null,
+		deInterlace: Boolean? = null,
+		requireNonAnamorphic: Boolean? = null,
+		transcodingMaxAudioChannels: Int? = null,
+		cpuCoreLimit: Int? = null,
+		liveStreamId: String? = null,
+		enableMpegtsM2TsMode: Boolean? = null,
+		videoCodec: String? = null,
+		subtitleCodec: String? = null,
+		transcodingReasons: String? = null,
+		audioStreamIndex: Int? = null,
+		videoStreamIndex: Int? = null,
+		context: EncodingContext,
+		streamOptions: Map<String, String>? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["container"] = container
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["static"] = static
+		queryParameters["params"] = params
+		queryParameters["tag"] = tag
+		queryParameters["deviceProfileId"] = deviceProfileId
+		queryParameters["playSessionId"] = playSessionId
+		queryParameters["segmentContainer"] = segmentContainer
+		queryParameters["segmentLength"] = segmentLength
+		queryParameters["minSegments"] = minSegments
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
+		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
+		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["audioSampleRate"] = audioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["audioBitRate"] = audioBitRate
+		queryParameters["audioChannels"] = audioChannels
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["profile"] = profile
+		queryParameters["level"] = level
+		queryParameters["framerate"] = framerate
+		queryParameters["maxFramerate"] = maxFramerate
+		queryParameters["copyTimestamps"] = copyTimestamps
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["videoBitRate"] = videoBitRate
+		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
+		queryParameters["subtitleMethod"] = subtitleMethod
+		queryParameters["maxRefFrames"] = maxRefFrames
+		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
+		queryParameters["requireAvc"] = requireAvc
+		queryParameters["deInterlace"] = deInterlace
+		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
+		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
+		queryParameters["cpuCoreLimit"] = cpuCoreLimit
+		queryParameters["liveStreamId"] = liveStreamId
+		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
+		queryParameters["videoCodec"] = videoCodec
+		queryParameters["subtitleCodec"] = subtitleCodec
+		queryParameters["transcodingReasons"] = transcodingReasons
+		queryParameters["audioStreamIndex"] = audioStreamIndex
+		queryParameters["videoStreamIndex"] = videoStreamIndex
+		queryParameters["context"] = context
+		queryParameters["streamOptions"] = streamOptions
+		return api.createUrl("/Audio/{itemId}/main.m3u8", pathParameters, queryParameters)
 	}
 
 	/**
@@ -560,6 +915,183 @@ class DynamicHlsApi(
 		val response = api.get<InputStream>("/Audio/{itemId}/master.m3u8", pathParameters,
 				queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Gets an audio hls playlist stream.
+	 *
+	 * @param itemId The item id.
+	 * @param container The video container. Possible values are: ts, webm, asf, wmv, ogv, mp4, m4v,
+	 * mkv, mpeg, mpg, avi, 3gp, wmv, wtv, m2ts, mov, iso, flv.
+	 * @param static Optional. If true, the original file will be streamed statically without any
+	 * encoding. Use either no url extension or the original file extension. true/false.
+	 * @param params The streaming parameters.
+	 * @param tag The tag.
+	 * @param deviceProfileId Optional. The dlna device profile id to utilize.
+	 * @param playSessionId The play session id.
+	 * @param segmentContainer The segment container.
+	 * @param segmentLength The segment lenght.
+	 * @param minSegments The minimum number of segments.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param audioCodec Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server
+	 * will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.
+	 * @param enableAutoStreamCopy Whether or not to allow automatic stream copy if requested values
+	 * match the original source. Defaults to true.
+	 * @param allowVideoStreamCopy Whether or not to allow copying of the video stream url.
+	 * @param allowAudioStreamCopy Whether or not to allow copying of the audio stream url.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param audioSampleRate Optional. Specify a specific audio sample rate, e.g. 44100.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param audioBitRate Optional. Specify an audio bitrate to encode to, e.g. 128000. If omitted
+	 * this will be left to encoder defaults.
+	 * @param audioChannels Optional. Specify a specific number of audio channels to encode to, e.g. 2.
+	 * @param maxAudioChannels Optional. Specify a maximum number of audio channels to encode to, e.g.
+	 * 2.
+	 * @param profile Optional. Specify a specific an encoder profile (varies by encoder), e.g. main,
+	 * baseline, high.
+	 * @param level Optional. Specify a level for the encoder profile (varies by encoder), e.g. 3, 3.1.
+	 * @param framerate Optional. A specific video framerate to encode to, e.g. 23.976. Generally this
+	 * should be omitted unless the device has specific requirements.
+	 * @param maxFramerate Optional. A specific maximum video framerate to encode to, e.g. 23.976.
+	 * Generally this should be omitted unless the device has specific requirements.
+	 * @param copyTimestamps Whether or not to copy timestamps when transcoding with an offset.
+	 * Defaults to false.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param width Optional. The fixed horizontal resolution of the encoded video.
+	 * @param height Optional. The fixed vertical resolution of the encoded video.
+	 * @param videoBitRate Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this
+	 * will be left to encoder defaults.
+	 * @param subtitleStreamIndex Optional. The index of the subtitle stream to use. If omitted no
+	 * subtitles will be used.
+	 * @param subtitleMethod Optional. Specify the subtitle delivery method.
+	 * @param maxRefFrames Optional.
+	 * @param maxVideoBitDepth Optional. The maximum video bit depth.
+	 * @param requireAvc Optional. Whether to require avc.
+	 * @param deInterlace Optional. Whether to deinterlace the video.
+	 * @param requireNonAnamorphic Optional. Whether to require a non anamporphic stream.
+	 * @param transcodingMaxAudioChannels Optional. The maximum number of audio channels to transcode.
+	 * @param cpuCoreLimit Optional. The limit of how many cpu cores to use.
+	 * @param liveStreamId The live stream id.
+	 * @param enableMpegtsM2TsMode Optional. Whether to enable the MpegtsM2Ts mode.
+	 * @param videoCodec Optional. Specify a video codec to encode to, e.g. h264. If omitted the server
+	 * will auto-select using the url's extension. Options: h265, h264, mpeg4, theora, vpx, wmv.
+	 * @param subtitleCodec Optional. Specify a subtitle codec to encode to.
+	 * @param transcodingReasons Optional. The transcoding reason.
+	 * @param audioStreamIndex Optional. The index of the audio stream to use. If omitted the first
+	 * audio stream will be used.
+	 * @param videoStreamIndex Optional. The index of the video stream to use. If omitted the first
+	 * video stream will be used.
+	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
+	 * @param streamOptions Optional. The streaming options.
+	 * @param enableAdaptiveBitrateStreaming Enable adaptive bitrate streaming.
+	 */
+	fun getMasterHlsAudioPlaylistUrl(
+		itemId: UUID,
+		container: String,
+		static: Boolean? = null,
+		params: String? = null,
+		tag: String? = null,
+		deviceProfileId: String? = null,
+		playSessionId: String? = null,
+		segmentContainer: String? = null,
+		segmentLength: Int? = null,
+		minSegments: Int? = null,
+		mediaSourceId: String,
+		deviceId: String? = null,
+		audioCodec: String? = null,
+		enableAutoStreamCopy: Boolean? = null,
+		allowVideoStreamCopy: Boolean? = null,
+		allowAudioStreamCopy: Boolean? = null,
+		breakOnNonKeyFrames: Boolean? = null,
+		audioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		audioBitRate: Int? = null,
+		audioChannels: Int? = null,
+		maxAudioChannels: Int? = null,
+		profile: String? = null,
+		level: String? = null,
+		framerate: Float? = null,
+		maxFramerate: Float? = null,
+		copyTimestamps: Boolean? = null,
+		startTimeTicks: Long? = null,
+		width: Int? = null,
+		height: Int? = null,
+		videoBitRate: Int? = null,
+		subtitleStreamIndex: Int? = null,
+		subtitleMethod: SubtitleDeliveryMethod,
+		maxRefFrames: Int? = null,
+		maxVideoBitDepth: Int? = null,
+		requireAvc: Boolean? = null,
+		deInterlace: Boolean? = null,
+		requireNonAnamorphic: Boolean? = null,
+		transcodingMaxAudioChannels: Int? = null,
+		cpuCoreLimit: Int? = null,
+		liveStreamId: String? = null,
+		enableMpegtsM2TsMode: Boolean? = null,
+		videoCodec: String? = null,
+		subtitleCodec: String? = null,
+		transcodingReasons: String? = null,
+		audioStreamIndex: Int? = null,
+		videoStreamIndex: Int? = null,
+		context: EncodingContext,
+		streamOptions: Map<String, String>? = null,
+		enableAdaptiveBitrateStreaming: Boolean
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["container"] = container
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["static"] = static
+		queryParameters["params"] = params
+		queryParameters["tag"] = tag
+		queryParameters["deviceProfileId"] = deviceProfileId
+		queryParameters["playSessionId"] = playSessionId
+		queryParameters["segmentContainer"] = segmentContainer
+		queryParameters["segmentLength"] = segmentLength
+		queryParameters["minSegments"] = minSegments
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
+		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
+		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["audioSampleRate"] = audioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["audioBitRate"] = audioBitRate
+		queryParameters["audioChannels"] = audioChannels
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["profile"] = profile
+		queryParameters["level"] = level
+		queryParameters["framerate"] = framerate
+		queryParameters["maxFramerate"] = maxFramerate
+		queryParameters["copyTimestamps"] = copyTimestamps
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["videoBitRate"] = videoBitRate
+		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
+		queryParameters["subtitleMethod"] = subtitleMethod
+		queryParameters["maxRefFrames"] = maxRefFrames
+		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
+		queryParameters["requireAvc"] = requireAvc
+		queryParameters["deInterlace"] = deInterlace
+		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
+		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
+		queryParameters["cpuCoreLimit"] = cpuCoreLimit
+		queryParameters["liveStreamId"] = liveStreamId
+		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
+		queryParameters["videoCodec"] = videoCodec
+		queryParameters["subtitleCodec"] = subtitleCodec
+		queryParameters["transcodingReasons"] = transcodingReasons
+		queryParameters["audioStreamIndex"] = audioStreamIndex
+		queryParameters["videoStreamIndex"] = videoStreamIndex
+		queryParameters["context"] = context
+		queryParameters["streamOptions"] = streamOptions
+		queryParameters["enableAdaptiveBitrateStreaming"] = enableAdaptiveBitrateStreaming
+		return api.createUrl("/Audio/{itemId}/master.m3u8", pathParameters, queryParameters)
 	}
 
 	/**
@@ -749,6 +1281,187 @@ class DynamicHlsApi(
 	 * Gets a video stream using HTTP live streaming.
 	 *
 	 * @param itemId The item id.
+	 * @param playlistId The playlist id.
+	 * @param segmentId The segment id.
+	 * @param container The video container. Possible values are: ts, webm, asf, wmv, ogv, mp4, m4v,
+	 * mkv, mpeg, mpg, avi, 3gp, wmv, wtv, m2ts, mov, iso, flv.
+	 * @param static Optional. If true, the original file will be streamed statically without any
+	 * encoding. Use either no url extension or the original file extension. true/false.
+	 * @param params The streaming parameters.
+	 * @param tag The tag.
+	 * @param deviceProfileId Optional. The dlna device profile id to utilize.
+	 * @param playSessionId The play session id.
+	 * @param segmentContainer The segment container.
+	 * @param segmentLength The segment lenght.
+	 * @param minSegments The minimum number of segments.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param audioCodec Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server
+	 * will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.
+	 * @param enableAutoStreamCopy Whether or not to allow automatic stream copy if requested values
+	 * match the original source. Defaults to true.
+	 * @param allowVideoStreamCopy Whether or not to allow copying of the video stream url.
+	 * @param allowAudioStreamCopy Whether or not to allow copying of the audio stream url.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param audioSampleRate Optional. Specify a specific audio sample rate, e.g. 44100.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param audioBitRate Optional. Specify an audio bitrate to encode to, e.g. 128000. If omitted
+	 * this will be left to encoder defaults.
+	 * @param audioChannels Optional. Specify a specific number of audio channels to encode to, e.g. 2.
+	 * @param maxAudioChannels Optional. Specify a maximum number of audio channels to encode to, e.g.
+	 * 2.
+	 * @param profile Optional. Specify a specific an encoder profile (varies by encoder), e.g. main,
+	 * baseline, high.
+	 * @param level Optional. Specify a level for the encoder profile (varies by encoder), e.g. 3, 3.1.
+	 * @param framerate Optional. A specific video framerate to encode to, e.g. 23.976. Generally this
+	 * should be omitted unless the device has specific requirements.
+	 * @param maxFramerate Optional. A specific maximum video framerate to encode to, e.g. 23.976.
+	 * Generally this should be omitted unless the device has specific requirements.
+	 * @param copyTimestamps Whether or not to copy timestamps when transcoding with an offset.
+	 * Defaults to false.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param width Optional. The fixed horizontal resolution of the encoded video.
+	 * @param height Optional. The fixed vertical resolution of the encoded video.
+	 * @param videoBitRate Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this
+	 * will be left to encoder defaults.
+	 * @param subtitleStreamIndex Optional. The index of the subtitle stream to use. If omitted no
+	 * subtitles will be used.
+	 * @param subtitleMethod Optional. Specify the subtitle delivery method.
+	 * @param maxRefFrames Optional.
+	 * @param maxVideoBitDepth Optional. The maximum video bit depth.
+	 * @param requireAvc Optional. Whether to require avc.
+	 * @param deInterlace Optional. Whether to deinterlace the video.
+	 * @param requireNonAnamorphic Optional. Whether to require a non anamporphic stream.
+	 * @param transcodingMaxAudioChannels Optional. The maximum number of audio channels to transcode.
+	 * @param cpuCoreLimit Optional. The limit of how many cpu cores to use.
+	 * @param liveStreamId The live stream id.
+	 * @param enableMpegtsM2TsMode Optional. Whether to enable the MpegtsM2Ts mode.
+	 * @param videoCodec Optional. Specify a video codec to encode to, e.g. h264. If omitted the server
+	 * will auto-select using the url's extension. Options: h265, h264, mpeg4, theora, vpx, wmv.
+	 * @param subtitleCodec Optional. Specify a subtitle codec to encode to.
+	 * @param transcodingReasons Optional. The transcoding reason.
+	 * @param audioStreamIndex Optional. The index of the audio stream to use. If omitted the first
+	 * audio stream will be used.
+	 * @param videoStreamIndex Optional. The index of the video stream to use. If omitted the first
+	 * video stream will be used.
+	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
+	 * @param streamOptions Optional. The streaming options.
+	 */
+	fun getHlsVideoSegmentUrl(
+		itemId: UUID,
+		playlistId: String,
+		segmentId: Int,
+		container: String,
+		static: Boolean? = null,
+		params: String? = null,
+		tag: String? = null,
+		deviceProfileId: String? = null,
+		playSessionId: String? = null,
+		segmentContainer: String? = null,
+		segmentLength: Int? = null,
+		minSegments: Int? = null,
+		mediaSourceId: String? = null,
+		deviceId: String? = null,
+		audioCodec: String? = null,
+		enableAutoStreamCopy: Boolean? = null,
+		allowVideoStreamCopy: Boolean? = null,
+		allowAudioStreamCopy: Boolean? = null,
+		breakOnNonKeyFrames: Boolean? = null,
+		audioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		audioBitRate: Int? = null,
+		audioChannels: Int? = null,
+		maxAudioChannels: Int? = null,
+		profile: String? = null,
+		level: String? = null,
+		framerate: Float? = null,
+		maxFramerate: Float? = null,
+		copyTimestamps: Boolean? = null,
+		startTimeTicks: Long? = null,
+		width: Int? = null,
+		height: Int? = null,
+		videoBitRate: Int? = null,
+		subtitleStreamIndex: Int? = null,
+		subtitleMethod: SubtitleDeliveryMethod,
+		maxRefFrames: Int? = null,
+		maxVideoBitDepth: Int? = null,
+		requireAvc: Boolean? = null,
+		deInterlace: Boolean? = null,
+		requireNonAnamorphic: Boolean? = null,
+		transcodingMaxAudioChannels: Int? = null,
+		cpuCoreLimit: Int? = null,
+		liveStreamId: String? = null,
+		enableMpegtsM2TsMode: Boolean? = null,
+		videoCodec: String? = null,
+		subtitleCodec: String? = null,
+		transcodingReasons: String? = null,
+		audioStreamIndex: Int? = null,
+		videoStreamIndex: Int? = null,
+		context: EncodingContext,
+		streamOptions: Map<String, String>? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["playlistId"] = playlistId
+		pathParameters["segmentId"] = segmentId
+		pathParameters["container"] = container
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["static"] = static
+		queryParameters["params"] = params
+		queryParameters["tag"] = tag
+		queryParameters["deviceProfileId"] = deviceProfileId
+		queryParameters["playSessionId"] = playSessionId
+		queryParameters["segmentContainer"] = segmentContainer
+		queryParameters["segmentLength"] = segmentLength
+		queryParameters["minSegments"] = minSegments
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
+		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
+		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["audioSampleRate"] = audioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["audioBitRate"] = audioBitRate
+		queryParameters["audioChannels"] = audioChannels
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["profile"] = profile
+		queryParameters["level"] = level
+		queryParameters["framerate"] = framerate
+		queryParameters["maxFramerate"] = maxFramerate
+		queryParameters["copyTimestamps"] = copyTimestamps
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["videoBitRate"] = videoBitRate
+		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
+		queryParameters["subtitleMethod"] = subtitleMethod
+		queryParameters["maxRefFrames"] = maxRefFrames
+		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
+		queryParameters["requireAvc"] = requireAvc
+		queryParameters["deInterlace"] = deInterlace
+		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
+		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
+		queryParameters["cpuCoreLimit"] = cpuCoreLimit
+		queryParameters["liveStreamId"] = liveStreamId
+		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
+		queryParameters["videoCodec"] = videoCodec
+		queryParameters["subtitleCodec"] = subtitleCodec
+		queryParameters["transcodingReasons"] = transcodingReasons
+		queryParameters["audioStreamIndex"] = audioStreamIndex
+		queryParameters["videoStreamIndex"] = videoStreamIndex
+		queryParameters["context"] = context
+		queryParameters["streamOptions"] = streamOptions
+		return api.createUrl("/Videos/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters,
+				queryParameters)
+	}
+
+	/**
+	 * Gets a video stream using HTTP live streaming.
+	 *
+	 * @param itemId The item id.
 	 * @param container The video container. Possible values are: ts, webm, asf, wmv, ogv, mp4, m4v,
 	 * mkv, mpeg, mpg, avi, 3gp, wmv, wtv, m2ts, mov, iso, flv.
 	 * @param static Optional. If true, the original file will be streamed statically without any
@@ -920,6 +1633,180 @@ class DynamicHlsApi(
 		val response = api.get<InputStream>("/Videos/{itemId}/main.m3u8", pathParameters, queryParameters,
 				data)
 		return response
+	}
+
+	/**
+	 * Gets a video stream using HTTP live streaming.
+	 *
+	 * @param itemId The item id.
+	 * @param container The video container. Possible values are: ts, webm, asf, wmv, ogv, mp4, m4v,
+	 * mkv, mpeg, mpg, avi, 3gp, wmv, wtv, m2ts, mov, iso, flv.
+	 * @param static Optional. If true, the original file will be streamed statically without any
+	 * encoding. Use either no url extension or the original file extension. true/false.
+	 * @param params The streaming parameters.
+	 * @param tag The tag.
+	 * @param deviceProfileId Optional. The dlna device profile id to utilize.
+	 * @param playSessionId The play session id.
+	 * @param segmentContainer The segment container.
+	 * @param segmentLength The segment lenght.
+	 * @param minSegments The minimum number of segments.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param audioCodec Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server
+	 * will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.
+	 * @param enableAutoStreamCopy Whether or not to allow automatic stream copy if requested values
+	 * match the original source. Defaults to true.
+	 * @param allowVideoStreamCopy Whether or not to allow copying of the video stream url.
+	 * @param allowAudioStreamCopy Whether or not to allow copying of the audio stream url.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param audioSampleRate Optional. Specify a specific audio sample rate, e.g. 44100.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param audioBitRate Optional. Specify an audio bitrate to encode to, e.g. 128000. If omitted
+	 * this will be left to encoder defaults.
+	 * @param audioChannels Optional. Specify a specific number of audio channels to encode to, e.g. 2.
+	 * @param maxAudioChannels Optional. Specify a maximum number of audio channels to encode to, e.g.
+	 * 2.
+	 * @param profile Optional. Specify a specific an encoder profile (varies by encoder), e.g. main,
+	 * baseline, high.
+	 * @param level Optional. Specify a level for the encoder profile (varies by encoder), e.g. 3, 3.1.
+	 * @param framerate Optional. A specific video framerate to encode to, e.g. 23.976. Generally this
+	 * should be omitted unless the device has specific requirements.
+	 * @param maxFramerate Optional. A specific maximum video framerate to encode to, e.g. 23.976.
+	 * Generally this should be omitted unless the device has specific requirements.
+	 * @param copyTimestamps Whether or not to copy timestamps when transcoding with an offset.
+	 * Defaults to false.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param width Optional. The fixed horizontal resolution of the encoded video.
+	 * @param height Optional. The fixed vertical resolution of the encoded video.
+	 * @param videoBitRate Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this
+	 * will be left to encoder defaults.
+	 * @param subtitleStreamIndex Optional. The index of the subtitle stream to use. If omitted no
+	 * subtitles will be used.
+	 * @param subtitleMethod Optional. Specify the subtitle delivery method.
+	 * @param maxRefFrames Optional.
+	 * @param maxVideoBitDepth Optional. The maximum video bit depth.
+	 * @param requireAvc Optional. Whether to require avc.
+	 * @param deInterlace Optional. Whether to deinterlace the video.
+	 * @param requireNonAnamorphic Optional. Whether to require a non anamporphic stream.
+	 * @param transcodingMaxAudioChannels Optional. The maximum number of audio channels to transcode.
+	 * @param cpuCoreLimit Optional. The limit of how many cpu cores to use.
+	 * @param liveStreamId The live stream id.
+	 * @param enableMpegtsM2TsMode Optional. Whether to enable the MpegtsM2Ts mode.
+	 * @param videoCodec Optional. Specify a video codec to encode to, e.g. h264. If omitted the server
+	 * will auto-select using the url's extension. Options: h265, h264, mpeg4, theora, vpx, wmv.
+	 * @param subtitleCodec Optional. Specify a subtitle codec to encode to.
+	 * @param transcodingReasons Optional. The transcoding reason.
+	 * @param audioStreamIndex Optional. The index of the audio stream to use. If omitted the first
+	 * audio stream will be used.
+	 * @param videoStreamIndex Optional. The index of the video stream to use. If omitted the first
+	 * video stream will be used.
+	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
+	 * @param streamOptions Optional. The streaming options.
+	 */
+	fun getVariantHlsVideoPlaylistUrl(
+		itemId: UUID,
+		container: String,
+		static: Boolean? = null,
+		params: String? = null,
+		tag: String? = null,
+		deviceProfileId: String? = null,
+		playSessionId: String? = null,
+		segmentContainer: String? = null,
+		segmentLength: Int? = null,
+		minSegments: Int? = null,
+		mediaSourceId: String? = null,
+		deviceId: String? = null,
+		audioCodec: String? = null,
+		enableAutoStreamCopy: Boolean? = null,
+		allowVideoStreamCopy: Boolean? = null,
+		allowAudioStreamCopy: Boolean? = null,
+		breakOnNonKeyFrames: Boolean? = null,
+		audioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		audioBitRate: Int? = null,
+		audioChannels: Int? = null,
+		maxAudioChannels: Int? = null,
+		profile: String? = null,
+		level: String? = null,
+		framerate: Float? = null,
+		maxFramerate: Float? = null,
+		copyTimestamps: Boolean? = null,
+		startTimeTicks: Long? = null,
+		width: Int? = null,
+		height: Int? = null,
+		videoBitRate: Int? = null,
+		subtitleStreamIndex: Int? = null,
+		subtitleMethod: SubtitleDeliveryMethod,
+		maxRefFrames: Int? = null,
+		maxVideoBitDepth: Int? = null,
+		requireAvc: Boolean? = null,
+		deInterlace: Boolean? = null,
+		requireNonAnamorphic: Boolean? = null,
+		transcodingMaxAudioChannels: Int? = null,
+		cpuCoreLimit: Int? = null,
+		liveStreamId: String? = null,
+		enableMpegtsM2TsMode: Boolean? = null,
+		videoCodec: String? = null,
+		subtitleCodec: String? = null,
+		transcodingReasons: String? = null,
+		audioStreamIndex: Int? = null,
+		videoStreamIndex: Int? = null,
+		context: EncodingContext,
+		streamOptions: Map<String, String>? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["container"] = container
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["static"] = static
+		queryParameters["params"] = params
+		queryParameters["tag"] = tag
+		queryParameters["deviceProfileId"] = deviceProfileId
+		queryParameters["playSessionId"] = playSessionId
+		queryParameters["segmentContainer"] = segmentContainer
+		queryParameters["segmentLength"] = segmentLength
+		queryParameters["minSegments"] = minSegments
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
+		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
+		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["audioSampleRate"] = audioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["audioBitRate"] = audioBitRate
+		queryParameters["audioChannels"] = audioChannels
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["profile"] = profile
+		queryParameters["level"] = level
+		queryParameters["framerate"] = framerate
+		queryParameters["maxFramerate"] = maxFramerate
+		queryParameters["copyTimestamps"] = copyTimestamps
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["videoBitRate"] = videoBitRate
+		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
+		queryParameters["subtitleMethod"] = subtitleMethod
+		queryParameters["maxRefFrames"] = maxRefFrames
+		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
+		queryParameters["requireAvc"] = requireAvc
+		queryParameters["deInterlace"] = deInterlace
+		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
+		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
+		queryParameters["cpuCoreLimit"] = cpuCoreLimit
+		queryParameters["liveStreamId"] = liveStreamId
+		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
+		queryParameters["videoCodec"] = videoCodec
+		queryParameters["subtitleCodec"] = subtitleCodec
+		queryParameters["transcodingReasons"] = transcodingReasons
+		queryParameters["audioStreamIndex"] = audioStreamIndex
+		queryParameters["videoStreamIndex"] = videoStreamIndex
+		queryParameters["context"] = context
+		queryParameters["streamOptions"] = streamOptions
+		return api.createUrl("/Videos/{itemId}/main.m3u8", pathParameters, queryParameters)
 	}
 
 	/**
@@ -1100,5 +1987,182 @@ class DynamicHlsApi(
 		val response = api.get<InputStream>("/Videos/{itemId}/master.m3u8", pathParameters,
 				queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Gets a video hls playlist stream.
+	 *
+	 * @param itemId The item id.
+	 * @param container The video container. Possible values are: ts, webm, asf, wmv, ogv, mp4, m4v,
+	 * mkv, mpeg, mpg, avi, 3gp, wmv, wtv, m2ts, mov, iso, flv.
+	 * @param static Optional. If true, the original file will be streamed statically without any
+	 * encoding. Use either no url extension or the original file extension. true/false.
+	 * @param params The streaming parameters.
+	 * @param tag The tag.
+	 * @param deviceProfileId Optional. The dlna device profile id to utilize.
+	 * @param playSessionId The play session id.
+	 * @param segmentContainer The segment container.
+	 * @param segmentLength The segment lenght.
+	 * @param minSegments The minimum number of segments.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param audioCodec Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server
+	 * will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.
+	 * @param enableAutoStreamCopy Whether or not to allow automatic stream copy if requested values
+	 * match the original source. Defaults to true.
+	 * @param allowVideoStreamCopy Whether or not to allow copying of the video stream url.
+	 * @param allowAudioStreamCopy Whether or not to allow copying of the audio stream url.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param audioSampleRate Optional. Specify a specific audio sample rate, e.g. 44100.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param audioBitRate Optional. Specify an audio bitrate to encode to, e.g. 128000. If omitted
+	 * this will be left to encoder defaults.
+	 * @param audioChannels Optional. Specify a specific number of audio channels to encode to, e.g. 2.
+	 * @param maxAudioChannels Optional. Specify a maximum number of audio channels to encode to, e.g.
+	 * 2.
+	 * @param profile Optional. Specify a specific an encoder profile (varies by encoder), e.g. main,
+	 * baseline, high.
+	 * @param level Optional. Specify a level for the encoder profile (varies by encoder), e.g. 3, 3.1.
+	 * @param framerate Optional. A specific video framerate to encode to, e.g. 23.976. Generally this
+	 * should be omitted unless the device has specific requirements.
+	 * @param maxFramerate Optional. A specific maximum video framerate to encode to, e.g. 23.976.
+	 * Generally this should be omitted unless the device has specific requirements.
+	 * @param copyTimestamps Whether or not to copy timestamps when transcoding with an offset.
+	 * Defaults to false.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param width Optional. The fixed horizontal resolution of the encoded video.
+	 * @param height Optional. The fixed vertical resolution of the encoded video.
+	 * @param videoBitRate Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this
+	 * will be left to encoder defaults.
+	 * @param subtitleStreamIndex Optional. The index of the subtitle stream to use. If omitted no
+	 * subtitles will be used.
+	 * @param subtitleMethod Optional. Specify the subtitle delivery method.
+	 * @param maxRefFrames Optional.
+	 * @param maxVideoBitDepth Optional. The maximum video bit depth.
+	 * @param requireAvc Optional. Whether to require avc.
+	 * @param deInterlace Optional. Whether to deinterlace the video.
+	 * @param requireNonAnamorphic Optional. Whether to require a non anamporphic stream.
+	 * @param transcodingMaxAudioChannels Optional. The maximum number of audio channels to transcode.
+	 * @param cpuCoreLimit Optional. The limit of how many cpu cores to use.
+	 * @param liveStreamId The live stream id.
+	 * @param enableMpegtsM2TsMode Optional. Whether to enable the MpegtsM2Ts mode.
+	 * @param videoCodec Optional. Specify a video codec to encode to, e.g. h264. If omitted the server
+	 * will auto-select using the url's extension. Options: h265, h264, mpeg4, theora, vpx, wmv.
+	 * @param subtitleCodec Optional. Specify a subtitle codec to encode to.
+	 * @param transcodingReasons Optional. The transcoding reason.
+	 * @param audioStreamIndex Optional. The index of the audio stream to use. If omitted the first
+	 * audio stream will be used.
+	 * @param videoStreamIndex Optional. The index of the video stream to use. If omitted the first
+	 * video stream will be used.
+	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
+	 * @param streamOptions Optional. The streaming options.
+	 * @param enableAdaptiveBitrateStreaming Enable adaptive bitrate streaming.
+	 */
+	fun getMasterHlsVideoPlaylistUrl(
+		itemId: UUID,
+		container: String,
+		static: Boolean? = null,
+		params: String? = null,
+		tag: String? = null,
+		deviceProfileId: String? = null,
+		playSessionId: String? = null,
+		segmentContainer: String? = null,
+		segmentLength: Int? = null,
+		minSegments: Int? = null,
+		mediaSourceId: String,
+		deviceId: String? = null,
+		audioCodec: String? = null,
+		enableAutoStreamCopy: Boolean? = null,
+		allowVideoStreamCopy: Boolean? = null,
+		allowAudioStreamCopy: Boolean? = null,
+		breakOnNonKeyFrames: Boolean? = null,
+		audioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		audioBitRate: Int? = null,
+		audioChannels: Int? = null,
+		maxAudioChannels: Int? = null,
+		profile: String? = null,
+		level: String? = null,
+		framerate: Float? = null,
+		maxFramerate: Float? = null,
+		copyTimestamps: Boolean? = null,
+		startTimeTicks: Long? = null,
+		width: Int? = null,
+		height: Int? = null,
+		videoBitRate: Int? = null,
+		subtitleStreamIndex: Int? = null,
+		subtitleMethod: SubtitleDeliveryMethod,
+		maxRefFrames: Int? = null,
+		maxVideoBitDepth: Int? = null,
+		requireAvc: Boolean? = null,
+		deInterlace: Boolean? = null,
+		requireNonAnamorphic: Boolean? = null,
+		transcodingMaxAudioChannels: Int? = null,
+		cpuCoreLimit: Int? = null,
+		liveStreamId: String? = null,
+		enableMpegtsM2TsMode: Boolean? = null,
+		videoCodec: String? = null,
+		subtitleCodec: String? = null,
+		transcodingReasons: String? = null,
+		audioStreamIndex: Int? = null,
+		videoStreamIndex: Int? = null,
+		context: EncodingContext,
+		streamOptions: Map<String, String>? = null,
+		enableAdaptiveBitrateStreaming: Boolean
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["container"] = container
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["static"] = static
+		queryParameters["params"] = params
+		queryParameters["tag"] = tag
+		queryParameters["deviceProfileId"] = deviceProfileId
+		queryParameters["playSessionId"] = playSessionId
+		queryParameters["segmentContainer"] = segmentContainer
+		queryParameters["segmentLength"] = segmentLength
+		queryParameters["minSegments"] = minSegments
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
+		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
+		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["audioSampleRate"] = audioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["audioBitRate"] = audioBitRate
+		queryParameters["audioChannels"] = audioChannels
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["profile"] = profile
+		queryParameters["level"] = level
+		queryParameters["framerate"] = framerate
+		queryParameters["maxFramerate"] = maxFramerate
+		queryParameters["copyTimestamps"] = copyTimestamps
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["videoBitRate"] = videoBitRate
+		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
+		queryParameters["subtitleMethod"] = subtitleMethod
+		queryParameters["maxRefFrames"] = maxRefFrames
+		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
+		queryParameters["requireAvc"] = requireAvc
+		queryParameters["deInterlace"] = deInterlace
+		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
+		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
+		queryParameters["cpuCoreLimit"] = cpuCoreLimit
+		queryParameters["liveStreamId"] = liveStreamId
+		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
+		queryParameters["videoCodec"] = videoCodec
+		queryParameters["subtitleCodec"] = subtitleCodec
+		queryParameters["transcodingReasons"] = transcodingReasons
+		queryParameters["audioStreamIndex"] = audioStreamIndex
+		queryParameters["videoStreamIndex"] = videoStreamIndex
+		queryParameters["context"] = context
+		queryParameters["streamOptions"] = streamOptions
+		queryParameters["enableAdaptiveBitrateStreaming"] = enableAdaptiveBitrateStreaming
+		return api.createUrl("/Videos/{itemId}/master.m3u8", pathParameters, queryParameters)
 	}
 }

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/EnvironmentApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/EnvironmentApi.kt
@@ -71,7 +71,7 @@ class EnvironmentApi(
 	/**
 	 * Gets network paths.
 	 */
-	@Deprecated("Deprecated in OpenAPI specification")
+	@Deprecated("This member is deprecated and may be removed in the future")
 	suspend fun getNetworkShares(): Response<List<FileSystemEntryInfo>> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = emptyMap<String, Any?>()

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/HlsSegmentApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/HlsSegmentApi.kt
@@ -38,6 +38,21 @@ class HlsSegmentApi(
 	 * @param itemId The item id.
 	 * @param segmentId The segment id.
 	 */
+	fun getHlsAudioSegmentLegacyAacUrl(itemId: String, segmentId: String): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["segmentId"] = segmentId
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/Audio/{itemId}/hls/{segmentId}/stream.aac", pathParameters,
+				queryParameters)
+	}
+
+	/**
+	 * Gets the specified audio segment for an audio item.
+	 *
+	 * @param itemId The item id.
+	 * @param segmentId The segment id.
+	 */
 	suspend fun getHlsAudioSegmentLegacyMp3(itemId: String, segmentId: String): Response<InputStream> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -47,6 +62,21 @@ class HlsSegmentApi(
 		val response = api.get<InputStream>("/Audio/{itemId}/hls/{segmentId}/stream.mp3", pathParameters,
 				queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Gets the specified audio segment for an audio item.
+	 *
+	 * @param itemId The item id.
+	 * @param segmentId The segment id.
+	 */
+	fun getHlsAudioSegmentLegacyMp3Url(itemId: String, segmentId: String): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["segmentId"] = segmentId
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/Audio/{itemId}/hls/{segmentId}/stream.mp3", pathParameters,
+				queryParameters)
 	}
 
 	/**
@@ -77,6 +107,30 @@ class HlsSegmentApi(
 	}
 
 	/**
+	 * Gets a hls video segment.
+	 *
+	 * @param itemId The item id.
+	 * @param playlistId The playlist id.
+	 * @param segmentId The segment id.
+	 * @param segmentContainer The segment container.
+	 */
+	fun getHlsVideoSegmentLegacyUrl(
+		itemId: String,
+		playlistId: String,
+		segmentId: String,
+		segmentContainer: String
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["playlistId"] = playlistId
+		pathParameters["segmentId"] = segmentId
+		pathParameters["segmentContainer"] = segmentContainer
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/Videos/{itemId}/hls/{playlistId}/{segmentId}.{segmentContainer}",
+				pathParameters, queryParameters)
+	}
+
+	/**
 	 * Gets a hls video playlist.
 	 *
 	 * @param itemId The video id.
@@ -91,6 +145,21 @@ class HlsSegmentApi(
 		val response = api.get<InputStream>("/Videos/{itemId}/hls/{playlistId}/stream.m3u8",
 				pathParameters, queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Gets a hls video playlist.
+	 *
+	 * @param itemId The video id.
+	 * @param playlistId The playlist id.
+	 */
+	fun getHlsPlaylistLegacyUrl(itemId: String, playlistId: String): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["playlistId"] = playlistId
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/Videos/{itemId}/hls/{playlistId}/stream.m3u8", pathParameters,
+				queryParameters)
 	}
 
 	/**

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ImageApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ImageApi.kt
@@ -91,6 +91,72 @@ class ImageApi(
 	}
 
 	/**
+	 * Get artist image by name.
+	 *
+	 * @param name Artist name.
+	 * @param imageType Image type.
+	 * @param tag Optional. Supply the cache tag from the item object to receive strong caching
+	 * headers.
+	 * @param format Determines the output format of the image - original,gif,jpg,png.
+	 * @param maxWidth The maximum image width to return.
+	 * @param maxHeight The maximum image height to return.
+	 * @param percentPlayed Optional. Percent to render for the percent played overlay.
+	 * @param unplayedCount Optional. Unplayed count overlay to render.
+	 * @param imageIndex Image index.
+	 * @param width The fixed image width to return.
+	 * @param height The fixed image height to return.
+	 * @param quality Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most
+	 * cases.
+	 * @param cropWhitespace Optional. Specify if whitespace should be cropped out of the image.
+	 * True/False. If unspecified, whitespace will be cropped from logos and clear art.
+	 * @param addPlayedIndicator Optional. Add a played indicator.
+	 * @param blur Optional. Blur image.
+	 * @param backgroundColor Optional. Apply a background color for transparent images.
+	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 */
+	fun getArtistImageUrl(
+		name: String,
+		imageType: ImageType,
+		tag: String,
+		format: String,
+		maxWidth: Int,
+		maxHeight: Int,
+		percentPlayed: Double,
+		unplayedCount: Int,
+		imageIndex: Int,
+		width: Int? = null,
+		height: Int? = null,
+		quality: Int? = null,
+		cropWhitespace: Boolean? = null,
+		addPlayedIndicator: Boolean? = null,
+		blur: Int? = null,
+		backgroundColor: String? = null,
+		foregroundLayer: String? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["name"] = name
+		pathParameters["imageType"] = imageType
+		pathParameters["tag"] = tag
+		pathParameters["format"] = format
+		pathParameters["maxWidth"] = maxWidth
+		pathParameters["maxHeight"] = maxHeight
+		pathParameters["percentPlayed"] = percentPlayed
+		pathParameters["unplayedCount"] = unplayedCount
+		pathParameters["imageIndex"] = imageIndex
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["quality"] = quality
+		queryParameters["cropWhitespace"] = cropWhitespace
+		queryParameters["addPlayedIndicator"] = addPlayedIndicator
+		queryParameters["blur"] = blur
+		queryParameters["backgroundColor"] = backgroundColor
+		queryParameters["foregroundLayer"] = foregroundLayer
+		return api.createUrl("/Artists/{name}/Images/{imageType}/{imageIndex}", pathParameters,
+				queryParameters)
+	}
+
+	/**
 	 * Get genre image by name.
 	 *
 	 * @param name Genre name.
@@ -156,6 +222,72 @@ class ImageApi(
 		val response = api.get<InputStream>("/Genres/{name}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Get genre image by name.
+	 *
+	 * @param name Genre name.
+	 * @param imageType Image type.
+	 * @param tag Optional. Supply the cache tag from the item object to receive strong caching
+	 * headers.
+	 * @param format Determines the output format of the image - original,gif,jpg,png.
+	 * @param maxWidth The maximum image width to return.
+	 * @param maxHeight The maximum image height to return.
+	 * @param percentPlayed Optional. Percent to render for the percent played overlay.
+	 * @param unplayedCount Optional. Unplayed count overlay to render.
+	 * @param imageIndex Image index.
+	 * @param width The fixed image width to return.
+	 * @param height The fixed image height to return.
+	 * @param quality Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most
+	 * cases.
+	 * @param cropWhitespace Optional. Specify if whitespace should be cropped out of the image.
+	 * True/False. If unspecified, whitespace will be cropped from logos and clear art.
+	 * @param addPlayedIndicator Optional. Add a played indicator.
+	 * @param blur Optional. Blur image.
+	 * @param backgroundColor Optional. Apply a background color for transparent images.
+	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 */
+	fun getGenreImageUrl(
+		name: String,
+		imageType: ImageType,
+		tag: String,
+		format: String,
+		maxWidth: Int,
+		maxHeight: Int,
+		percentPlayed: Double,
+		unplayedCount: Int,
+		imageIndex: Int,
+		width: Int? = null,
+		height: Int? = null,
+		quality: Int? = null,
+		cropWhitespace: Boolean? = null,
+		addPlayedIndicator: Boolean? = null,
+		blur: Int? = null,
+		backgroundColor: String? = null,
+		foregroundLayer: String? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["name"] = name
+		pathParameters["imageType"] = imageType
+		pathParameters["tag"] = tag
+		pathParameters["format"] = format
+		pathParameters["maxWidth"] = maxWidth
+		pathParameters["maxHeight"] = maxHeight
+		pathParameters["percentPlayed"] = percentPlayed
+		pathParameters["unplayedCount"] = unplayedCount
+		pathParameters["imageIndex"] = imageIndex
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["quality"] = quality
+		queryParameters["cropWhitespace"] = cropWhitespace
+		queryParameters["addPlayedIndicator"] = addPlayedIndicator
+		queryParameters["blur"] = blur
+		queryParameters["backgroundColor"] = backgroundColor
+		queryParameters["foregroundLayer"] = foregroundLayer
+		return api.createUrl("/Genres/{name}/Images/{imageType}/{imageIndex}", pathParameters,
+				queryParameters)
 	}
 
 	/**
@@ -239,6 +371,71 @@ class ImageApi(
 		val response = api.get<InputStream>("/Items/{itemId}/Images/{imageType}", pathParameters,
 				queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Gets the item's image.
+	 *
+	 * @param itemId Item id.
+	 * @param imageType Image type.
+	 * @param maxWidth The maximum image width to return.
+	 * @param maxHeight The maximum image height to return.
+	 * @param imageIndex Image index.
+	 * @param width The fixed image width to return.
+	 * @param height The fixed image height to return.
+	 * @param quality Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most
+	 * cases.
+	 * @param tag Optional. Supply the cache tag from the item object to receive strong caching
+	 * headers.
+	 * @param cropWhitespace Optional. Specify if whitespace should be cropped out of the image.
+	 * True/False. If unspecified, whitespace will be cropped from logos and clear art.
+	 * @param format Determines the output format of the image - original,gif,jpg,png.
+	 * @param addPlayedIndicator Optional. Add a played indicator.
+	 * @param percentPlayed Optional. Percent to render for the percent played overlay.
+	 * @param unplayedCount Optional. Unplayed count overlay to render.
+	 * @param blur Optional. Blur image.
+	 * @param backgroundColor Optional. Apply a background color for transparent images.
+	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 */
+	fun getItemImageUrl(
+		itemId: UUID,
+		imageType: ImageType,
+		maxWidth: Int,
+		maxHeight: Int,
+		imageIndex: Int,
+		width: Int? = null,
+		height: Int? = null,
+		quality: Int? = null,
+		tag: String? = null,
+		cropWhitespace: Boolean? = null,
+		format: String? = null,
+		addPlayedIndicator: Boolean? = null,
+		percentPlayed: Double? = null,
+		unplayedCount: Int? = null,
+		blur: Int? = null,
+		backgroundColor: String? = null,
+		foregroundLayer: String? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["imageType"] = imageType
+		pathParameters["maxWidth"] = maxWidth
+		pathParameters["maxHeight"] = maxHeight
+		pathParameters["imageIndex"] = imageIndex
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["quality"] = quality
+		queryParameters["tag"] = tag
+		queryParameters["cropWhitespace"] = cropWhitespace
+		queryParameters["format"] = format
+		queryParameters["addPlayedIndicator"] = addPlayedIndicator
+		queryParameters["percentPlayed"] = percentPlayed
+		queryParameters["unplayedCount"] = unplayedCount
+		queryParameters["blur"] = blur
+		queryParameters["backgroundColor"] = backgroundColor
+		queryParameters["foregroundLayer"] = foregroundLayer
+		return api.createUrl("/Items/{itemId}/Images/{imageType}", pathParameters, queryParameters)
 	}
 
 	/**
@@ -353,6 +550,72 @@ class ImageApi(
 		val response = api.get<InputStream>("/Items/{itemId}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Gets the item's image.
+	 *
+	 * @param itemId Item id.
+	 * @param imageType Image type.
+	 * @param maxWidth The maximum image width to return.
+	 * @param maxHeight The maximum image height to return.
+	 * @param imageIndex Image index.
+	 * @param width The fixed image width to return.
+	 * @param height The fixed image height to return.
+	 * @param quality Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most
+	 * cases.
+	 * @param tag Optional. Supply the cache tag from the item object to receive strong caching
+	 * headers.
+	 * @param cropWhitespace Optional. Specify if whitespace should be cropped out of the image.
+	 * True/False. If unspecified, whitespace will be cropped from logos and clear art.
+	 * @param format Determines the output format of the image - original,gif,jpg,png.
+	 * @param addPlayedIndicator Optional. Add a played indicator.
+	 * @param percentPlayed Optional. Percent to render for the percent played overlay.
+	 * @param unplayedCount Optional. Unplayed count overlay to render.
+	 * @param blur Optional. Blur image.
+	 * @param backgroundColor Optional. Apply a background color for transparent images.
+	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 */
+	fun getItemImage_2Url(
+		itemId: UUID,
+		imageType: ImageType,
+		maxWidth: Int,
+		maxHeight: Int,
+		imageIndex: Int,
+		width: Int? = null,
+		height: Int? = null,
+		quality: Int? = null,
+		tag: String? = null,
+		cropWhitespace: Boolean? = null,
+		format: String? = null,
+		addPlayedIndicator: Boolean? = null,
+		percentPlayed: Double? = null,
+		unplayedCount: Int? = null,
+		blur: Int? = null,
+		backgroundColor: String? = null,
+		foregroundLayer: String? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["imageType"] = imageType
+		pathParameters["maxWidth"] = maxWidth
+		pathParameters["maxHeight"] = maxHeight
+		pathParameters["imageIndex"] = imageIndex
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["quality"] = quality
+		queryParameters["tag"] = tag
+		queryParameters["cropWhitespace"] = cropWhitespace
+		queryParameters["format"] = format
+		queryParameters["addPlayedIndicator"] = addPlayedIndicator
+		queryParameters["percentPlayed"] = percentPlayed
+		queryParameters["unplayedCount"] = unplayedCount
+		queryParameters["blur"] = blur
+		queryParameters["backgroundColor"] = backgroundColor
+		queryParameters["foregroundLayer"] = foregroundLayer
+		return api.createUrl("/Items/{itemId}/Images/{imageType}/{imageIndex}", pathParameters,
+				queryParameters)
 	}
 
 	/**
@@ -471,6 +734,73 @@ class ImageApi(
 	}
 
 	/**
+	 * Gets the item's image.
+	 *
+	 * @param itemId Item id.
+	 * @param imageType Image type.
+	 * @param maxWidth The maximum image width to return.
+	 * @param maxHeight The maximum image height to return.
+	 * @param tag Optional. Supply the cache tag from the item object to receive strong caching
+	 * headers.
+	 * @param format Determines the output format of the image - original,gif,jpg,png.
+	 * @param percentPlayed Optional. Percent to render for the percent played overlay.
+	 * @param unplayedCount Optional. Unplayed count overlay to render.
+	 * @param imageIndex Image index.
+	 * @param width The fixed image width to return.
+	 * @param height The fixed image height to return.
+	 * @param quality Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most
+	 * cases.
+	 * @param cropWhitespace Optional. Specify if whitespace should be cropped out of the image.
+	 * True/False. If unspecified, whitespace will be cropped from logos and clear art.
+	 * @param addPlayedIndicator Optional. Add a played indicator.
+	 * @param blur Optional. Blur image.
+	 * @param backgroundColor Optional. Apply a background color for transparent images.
+	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 */
+	fun getItemImage2Url(
+		itemId: UUID,
+		imageType: ImageType,
+		maxWidth: Int,
+		maxHeight: Int,
+		tag: String,
+		format: String,
+		percentPlayed: Double,
+		unplayedCount: Int,
+		imageIndex: Int,
+		width: Int? = null,
+		height: Int? = null,
+		quality: Int? = null,
+		cropWhitespace: Boolean? = null,
+		addPlayedIndicator: Boolean? = null,
+		blur: Int? = null,
+		backgroundColor: String? = null,
+		foregroundLayer: String? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["imageType"] = imageType
+		pathParameters["maxWidth"] = maxWidth
+		pathParameters["maxHeight"] = maxHeight
+		pathParameters["tag"] = tag
+		pathParameters["format"] = format
+		pathParameters["percentPlayed"] = percentPlayed
+		pathParameters["unplayedCount"] = unplayedCount
+		pathParameters["imageIndex"] = imageIndex
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["quality"] = quality
+		queryParameters["cropWhitespace"] = cropWhitespace
+		queryParameters["addPlayedIndicator"] = addPlayedIndicator
+		queryParameters["blur"] = blur
+		queryParameters["backgroundColor"] = backgroundColor
+		queryParameters["foregroundLayer"] = foregroundLayer
+		return
+				api.createUrl("/Items/{itemId}/Images/{imageType}/{imageIndex}/{tag}/{format}/{maxWidth}/{maxHeight}/{percentPlayed}/{unplayedCount}",
+				pathParameters, queryParameters)
+	}
+
+	/**
 	 * Updates the index for an item image.
 	 *
 	 * @param itemId Item id.
@@ -565,6 +895,72 @@ class ImageApi(
 	}
 
 	/**
+	 * Get music genre image by name.
+	 *
+	 * @param name Music genre name.
+	 * @param imageType Image type.
+	 * @param tag Optional. Supply the cache tag from the item object to receive strong caching
+	 * headers.
+	 * @param format Determines the output format of the image - original,gif,jpg,png.
+	 * @param maxWidth The maximum image width to return.
+	 * @param maxHeight The maximum image height to return.
+	 * @param percentPlayed Optional. Percent to render for the percent played overlay.
+	 * @param unplayedCount Optional. Unplayed count overlay to render.
+	 * @param imageIndex Image index.
+	 * @param width The fixed image width to return.
+	 * @param height The fixed image height to return.
+	 * @param quality Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most
+	 * cases.
+	 * @param cropWhitespace Optional. Specify if whitespace should be cropped out of the image.
+	 * True/False. If unspecified, whitespace will be cropped from logos and clear art.
+	 * @param addPlayedIndicator Optional. Add a played indicator.
+	 * @param blur Optional. Blur image.
+	 * @param backgroundColor Optional. Apply a background color for transparent images.
+	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 */
+	fun getMusicGenreImageUrl(
+		name: String,
+		imageType: ImageType,
+		tag: String,
+		format: String,
+		maxWidth: Int,
+		maxHeight: Int,
+		percentPlayed: Double,
+		unplayedCount: Int,
+		imageIndex: Int,
+		width: Int? = null,
+		height: Int? = null,
+		quality: Int? = null,
+		cropWhitespace: Boolean? = null,
+		addPlayedIndicator: Boolean? = null,
+		blur: Int? = null,
+		backgroundColor: String? = null,
+		foregroundLayer: String? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["name"] = name
+		pathParameters["imageType"] = imageType
+		pathParameters["tag"] = tag
+		pathParameters["format"] = format
+		pathParameters["maxWidth"] = maxWidth
+		pathParameters["maxHeight"] = maxHeight
+		pathParameters["percentPlayed"] = percentPlayed
+		pathParameters["unplayedCount"] = unplayedCount
+		pathParameters["imageIndex"] = imageIndex
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["quality"] = quality
+		queryParameters["cropWhitespace"] = cropWhitespace
+		queryParameters["addPlayedIndicator"] = addPlayedIndicator
+		queryParameters["blur"] = blur
+		queryParameters["backgroundColor"] = backgroundColor
+		queryParameters["foregroundLayer"] = foregroundLayer
+		return api.createUrl("/MusicGenres/{name}/Images/{imageType}/{imageIndex}", pathParameters,
+				queryParameters)
+	}
+
+	/**
 	 * Get person image by name.
 	 *
 	 * @param name Person name.
@@ -633,6 +1029,72 @@ class ImageApi(
 	}
 
 	/**
+	 * Get person image by name.
+	 *
+	 * @param name Person name.
+	 * @param imageType Image type.
+	 * @param tag Optional. Supply the cache tag from the item object to receive strong caching
+	 * headers.
+	 * @param format Determines the output format of the image - original,gif,jpg,png.
+	 * @param maxWidth The maximum image width to return.
+	 * @param maxHeight The maximum image height to return.
+	 * @param percentPlayed Optional. Percent to render for the percent played overlay.
+	 * @param unplayedCount Optional. Unplayed count overlay to render.
+	 * @param imageIndex Image index.
+	 * @param width The fixed image width to return.
+	 * @param height The fixed image height to return.
+	 * @param quality Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most
+	 * cases.
+	 * @param cropWhitespace Optional. Specify if whitespace should be cropped out of the image.
+	 * True/False. If unspecified, whitespace will be cropped from logos and clear art.
+	 * @param addPlayedIndicator Optional. Add a played indicator.
+	 * @param blur Optional. Blur image.
+	 * @param backgroundColor Optional. Apply a background color for transparent images.
+	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 */
+	fun getPersonImageUrl(
+		name: String,
+		imageType: ImageType,
+		tag: String,
+		format: String,
+		maxWidth: Int,
+		maxHeight: Int,
+		percentPlayed: Double,
+		unplayedCount: Int,
+		imageIndex: Int,
+		width: Int? = null,
+		height: Int? = null,
+		quality: Int? = null,
+		cropWhitespace: Boolean? = null,
+		addPlayedIndicator: Boolean? = null,
+		blur: Int? = null,
+		backgroundColor: String? = null,
+		foregroundLayer: String? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["name"] = name
+		pathParameters["imageType"] = imageType
+		pathParameters["tag"] = tag
+		pathParameters["format"] = format
+		pathParameters["maxWidth"] = maxWidth
+		pathParameters["maxHeight"] = maxHeight
+		pathParameters["percentPlayed"] = percentPlayed
+		pathParameters["unplayedCount"] = unplayedCount
+		pathParameters["imageIndex"] = imageIndex
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["quality"] = quality
+		queryParameters["cropWhitespace"] = cropWhitespace
+		queryParameters["addPlayedIndicator"] = addPlayedIndicator
+		queryParameters["blur"] = blur
+		queryParameters["backgroundColor"] = backgroundColor
+		queryParameters["foregroundLayer"] = foregroundLayer
+		return api.createUrl("/Persons/{name}/Images/{imageType}/{imageIndex}", pathParameters,
+				queryParameters)
+	}
+
+	/**
 	 * Get studio image by name.
 	 *
 	 * @param name Studio name.
@@ -698,6 +1160,72 @@ class ImageApi(
 		val response = api.get<InputStream>("/Studios/{name}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Get studio image by name.
+	 *
+	 * @param name Studio name.
+	 * @param imageType Image type.
+	 * @param tag Optional. Supply the cache tag from the item object to receive strong caching
+	 * headers.
+	 * @param format Determines the output format of the image - original,gif,jpg,png.
+	 * @param maxWidth The maximum image width to return.
+	 * @param maxHeight The maximum image height to return.
+	 * @param percentPlayed Optional. Percent to render for the percent played overlay.
+	 * @param unplayedCount Optional. Unplayed count overlay to render.
+	 * @param imageIndex Image index.
+	 * @param width The fixed image width to return.
+	 * @param height The fixed image height to return.
+	 * @param quality Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most
+	 * cases.
+	 * @param cropWhitespace Optional. Specify if whitespace should be cropped out of the image.
+	 * True/False. If unspecified, whitespace will be cropped from logos and clear art.
+	 * @param addPlayedIndicator Optional. Add a played indicator.
+	 * @param blur Optional. Blur image.
+	 * @param backgroundColor Optional. Apply a background color for transparent images.
+	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 */
+	fun getStudioImageUrl(
+		name: String,
+		imageType: ImageType,
+		tag: String,
+		format: String,
+		maxWidth: Int,
+		maxHeight: Int,
+		percentPlayed: Double,
+		unplayedCount: Int,
+		imageIndex: Int,
+		width: Int? = null,
+		height: Int? = null,
+		quality: Int? = null,
+		cropWhitespace: Boolean? = null,
+		addPlayedIndicator: Boolean? = null,
+		blur: Int? = null,
+		backgroundColor: String? = null,
+		foregroundLayer: String? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["name"] = name
+		pathParameters["imageType"] = imageType
+		pathParameters["tag"] = tag
+		pathParameters["format"] = format
+		pathParameters["maxWidth"] = maxWidth
+		pathParameters["maxHeight"] = maxHeight
+		pathParameters["percentPlayed"] = percentPlayed
+		pathParameters["unplayedCount"] = unplayedCount
+		pathParameters["imageIndex"] = imageIndex
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["quality"] = quality
+		queryParameters["cropWhitespace"] = cropWhitespace
+		queryParameters["addPlayedIndicator"] = addPlayedIndicator
+		queryParameters["blur"] = blur
+		queryParameters["backgroundColor"] = backgroundColor
+		queryParameters["foregroundLayer"] = foregroundLayer
+		return api.createUrl("/Studios/{name}/Images/{imageType}/{imageIndex}", pathParameters,
+				queryParameters)
 	}
 
 	/**
@@ -789,6 +1317,72 @@ class ImageApi(
 		val response = api.get<InputStream>("/Users/{userId}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Get user profile image.
+	 *
+	 * @param userId User id.
+	 * @param imageType Image type.
+	 * @param imageIndex Image index.
+	 * @param tag Optional. Supply the cache tag from the item object to receive strong caching
+	 * headers.
+	 * @param format Determines the output format of the image - original,gif,jpg,png.
+	 * @param maxWidth The maximum image width to return.
+	 * @param maxHeight The maximum image height to return.
+	 * @param percentPlayed Optional. Percent to render for the percent played overlay.
+	 * @param unplayedCount Optional. Unplayed count overlay to render.
+	 * @param width The fixed image width to return.
+	 * @param height The fixed image height to return.
+	 * @param quality Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most
+	 * cases.
+	 * @param cropWhitespace Optional. Specify if whitespace should be cropped out of the image.
+	 * True/False. If unspecified, whitespace will be cropped from logos and clear art.
+	 * @param addPlayedIndicator Optional. Add a played indicator.
+	 * @param blur Optional. Blur image.
+	 * @param backgroundColor Optional. Apply a background color for transparent images.
+	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 */
+	fun getUserImageUrl(
+		userId: UUID,
+		imageType: ImageType,
+		imageIndex: Int,
+		tag: String? = null,
+		format: String? = null,
+		maxWidth: Int? = null,
+		maxHeight: Int? = null,
+		percentPlayed: Double? = null,
+		unplayedCount: Int? = null,
+		width: Int? = null,
+		height: Int? = null,
+		quality: Int? = null,
+		cropWhitespace: Boolean? = null,
+		addPlayedIndicator: Boolean? = null,
+		blur: Int? = null,
+		backgroundColor: String? = null,
+		foregroundLayer: String? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["userId"] = userId
+		pathParameters["imageType"] = imageType
+		pathParameters["imageIndex"] = imageIndex
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["tag"] = tag
+		queryParameters["format"] = format
+		queryParameters["maxWidth"] = maxWidth
+		queryParameters["maxHeight"] = maxHeight
+		queryParameters["percentPlayed"] = percentPlayed
+		queryParameters["unplayedCount"] = unplayedCount
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["quality"] = quality
+		queryParameters["cropWhitespace"] = cropWhitespace
+		queryParameters["addPlayedIndicator"] = addPlayedIndicator
+		queryParameters["blur"] = blur
+		queryParameters["backgroundColor"] = backgroundColor
+		queryParameters["foregroundLayer"] = foregroundLayer
+		return api.createUrl("/Users/{userId}/Images/{imageType}/{imageIndex}", pathParameters,
+				queryParameters)
 	}
 
 	/**

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ImageApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ImageApi.kt
@@ -795,8 +795,7 @@ class ImageApi(
 		queryParameters["blur"] = blur
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
-		return
-				api.createUrl("/Items/{itemId}/Images/{imageType}/{imageIndex}/{tag}/{format}/{maxWidth}/{maxHeight}/{percentPlayed}/{unplayedCount}",
+		return api.createUrl("/Items/{itemId}/Images/{imageType}/{imageIndex}/{tag}/{format}/{maxWidth}/{maxHeight}/{percentPlayed}/{unplayedCount}",
 				pathParameters, queryParameters)
 	}
 

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ImageByNameApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ImageByNameApi.kt
@@ -46,6 +46,20 @@ class ImageByNameApi(
 	}
 
 	/**
+	 * Get General Image.
+	 *
+	 * @param name The name of the image.
+	 * @param type Image Type (primary, backdrop, logo, etc).
+	 */
+	fun getGeneralImageUrl(name: String, type: String): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["name"] = name
+		pathParameters["type"] = type
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/Images/General/{name}/{type}", pathParameters, queryParameters)
+	}
+
+	/**
 	 * Get all media info images.
 	 */
 	suspend fun getMediaInfoImages(): Response<List<ImageByNameInfo>> {
@@ -75,6 +89,20 @@ class ImageByNameApi(
 	}
 
 	/**
+	 * Get media info image.
+	 *
+	 * @param theme The theme to get the image from.
+	 * @param name The name of the image.
+	 */
+	fun getMediaInfoImageUrl(theme: String, name: String): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["theme"] = theme
+		pathParameters["name"] = name
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/Images/MediaInfo/{theme}/{name}", pathParameters, queryParameters)
+	}
+
+	/**
 	 * Get all general images.
 	 */
 	suspend fun getRatingImages(): Response<List<ImageByNameInfo>> {
@@ -101,5 +129,19 @@ class ImageByNameApi(
 		val response = api.get<InputStream>("/Images/Ratings/{theme}/{name}", pathParameters,
 				queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Get rating image.
+	 *
+	 * @param theme The theme to get the image from.
+	 * @param name The name of the image.
+	 */
+	fun getRatingImageUrl(theme: String, name: String): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["theme"] = theme
+		pathParameters["name"] = name
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/Images/Ratings/{theme}/{name}", pathParameters, queryParameters)
 	}
 }

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ItemLookupApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ItemLookupApi.kt
@@ -108,6 +108,20 @@ class ItemLookupApi(
 	}
 
 	/**
+	 * Gets a remote image.
+	 *
+	 * @param imageUrl The image url.
+	 * @param providerName The provider name.
+	 */
+	fun getRemoteSearchImageUrl(imageUrl: String, providerName: String): String {
+		val pathParameters = emptyMap<String, Any?>()
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["imageUrl"] = imageUrl
+		queryParameters["providerName"] = providerName
+		return api.createUrl("/Items/RemoteSearch/Image", pathParameters, queryParameters)
+	}
+
+	/**
 	 * Get movie remote search.
 	 */
 	suspend fun getMovieRemoteSearchResults(data: MovieInfoRemoteSearchQuery):

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LibraryApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LibraryApi.kt
@@ -139,7 +139,7 @@ class LibraryApi(
 	/**
 	 * Gets critic review for an item.
 	 */
-	@Deprecated("Deprecated in OpenAPI specification")
+	@Deprecated("This member is deprecated and may be removed in the future")
 	suspend fun getCriticReviews(itemId: String): Response<BaseItemDtoQueryResult> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -166,6 +166,18 @@ class LibraryApi(
 	}
 
 	/**
+	 * Downloads item media.
+	 *
+	 * @param itemId The item id.
+	 */
+	fun getDownloadUrl(itemId: UUID): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/Items/{itemId}/Download", pathParameters, queryParameters)
+	}
+
+	/**
 	 * Get the original file of an item.
 	 *
 	 * @param itemId The item id.
@@ -177,6 +189,18 @@ class LibraryApi(
 		val data = null
 		val response = api.get<InputStream>("/Items/{itemId}/File", pathParameters, queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Get the original file of an item.
+	 *
+	 * @param itemId The item id.
+	 */
+	fun getFileUrl(itemId: UUID): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/Items/{itemId}/File", pathParameters, queryParameters)
 	}
 
 	/**

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LiveTvApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LiveTvApi.kt
@@ -286,6 +286,16 @@ class LiveTvApi(
 	}
 
 	/**
+	 * Gets available countries.
+	 */
+	fun getSchedulesDirectCountriesUrl(): String {
+		val pathParameters = emptyMap<String, Any?>()
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/LiveTv/ListingProviders/SchedulesDirect/Countries", pathParameters,
+				queryParameters)
+	}
+
+	/**
 	 * Gets a live tv recording stream.
 	 *
 	 * @param recordingId Recording id.
@@ -298,6 +308,19 @@ class LiveTvApi(
 		val response = api.get<InputStream>("/LiveTv/LiveRecordings/{recordingId}/stream", pathParameters,
 				queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Gets a live tv recording stream.
+	 *
+	 * @param recordingId Recording id.
+	 */
+	fun getLiveRecordingFileUrl(recordingId: String): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["recordingId"] = recordingId
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/LiveTv/LiveRecordings/{recordingId}/stream", pathParameters,
+				queryParameters)
 	}
 
 	/**
@@ -315,6 +338,21 @@ class LiveTvApi(
 		val response = api.get<InputStream>("/LiveTv/LiveStreamFiles/{streamId}/stream.{container}",
 				pathParameters, queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Gets a live tv channel stream.
+	 *
+	 * @param streamId Stream id.
+	 * @param container Container type.
+	 */
+	fun getLiveStreamFileUrl(streamId: String, container: String): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["streamId"] = streamId
+		pathParameters["container"] = container
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/LiveTv/LiveStreamFiles/{streamId}/stream.{container}", pathParameters,
+				queryParameters)
 	}
 
 	/**
@@ -637,7 +675,7 @@ class LiveTvApi(
 	 *
 	 * @param userId Optional. Filter by user and attach user data.
 	 */
-	@Deprecated("Deprecated in OpenAPI specification")
+	@Deprecated("This member is deprecated and may be removed in the future")
 	suspend fun getRecordingGroups(userId: UUID? = null): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
@@ -653,7 +691,7 @@ class LiveTvApi(
 	 *
 	 * @param groupId Group id.
 	 */
-	@Deprecated("Deprecated in OpenAPI specification")
+	@Deprecated("This member is deprecated and may be removed in the future")
 	suspend fun getRecordingGroup(groupId: UUID): Response<Unit> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["groupId"] = groupId
@@ -686,7 +724,7 @@ class LiveTvApi(
 	 * @param enableUserData Optional. Include user data.
 	 * @param enableTotalRecordCount Optional. Return total record count.
 	 */
-	@Deprecated("Deprecated in OpenAPI specification")
+	@Deprecated("This member is deprecated and may be removed in the future")
 	suspend fun getRecordingsSeries(
 		channelId: String? = null,
 		userId: UUID? = null,

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MediaInfoApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MediaInfoApi.kt
@@ -174,4 +174,16 @@ class MediaInfoApi(
 				data)
 		return response
 	}
+
+	/**
+	 * Tests the network with a request with the size of the bitrate.
+	 *
+	 * @param size The bitrate. Defaults to 102400.
+	 */
+	fun getBitrateTestBytesUrl(size: Int): String {
+		val pathParameters = emptyMap<String, Any?>()
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["size"] = size
+		return api.createUrl("/Playback/BitrateTest", pathParameters, queryParameters)
+	}
 }

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/PluginsApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/PluginsApi.kt
@@ -81,7 +81,7 @@ class PluginsApi(
 	 *
 	 * @param name Feature name.
 	 */
-	@Deprecated("Deprecated in OpenAPI specification")
+	@Deprecated("This member is deprecated and may be removed in the future")
 	suspend fun getRegistrationStatus(name: String): Response<MbRegistrationRecord> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
@@ -97,7 +97,7 @@ class PluginsApi(
 	 *
 	 * @param name Feature name.
 	 */
-	@Deprecated("Deprecated in OpenAPI specification")
+	@Deprecated("This member is deprecated and may be removed in the future")
 	suspend fun getRegistration(name: String): Response<Unit> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
@@ -111,7 +111,7 @@ class PluginsApi(
 	/**
 	 * Get plugin security info.
 	 */
-	@Deprecated("Deprecated in OpenAPI specification")
+	@Deprecated("This member is deprecated and may be removed in the future")
 	suspend fun getPluginSecurityInfo(): Response<PluginSecurityInfo> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = emptyMap<String, Any?>()
@@ -124,7 +124,7 @@ class PluginsApi(
 	/**
 	 * Updates plugin security info.
 	 */
-	@Deprecated("Deprecated in OpenAPI specification")
+	@Deprecated("This member is deprecated and may be removed in the future")
 	suspend fun updatePluginSecurityInfo(data: PluginSecurityInfo): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = emptyMap<String, Any?>()

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/RemoteImageApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/RemoteImageApi.kt
@@ -37,6 +37,18 @@ class RemoteImageApi(
 	}
 
 	/**
+	 * Gets a remote image.
+	 *
+	 * @param imageUrl The image url.
+	 */
+	fun getRemoteImageUrl(imageUrl: String): String {
+		val pathParameters = emptyMap<String, Any?>()
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["imageUrl"] = imageUrl
+		return api.createUrl("/Images/Remote", pathParameters, queryParameters)
+	}
+
+	/**
 	 * Gets available remote images for an item.
 	 *
 	 * @param itemId Item Id.

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/SubtitleApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/SubtitleApi.kt
@@ -183,6 +183,30 @@ class SubtitleApi(
 	}
 
 	/**
+	 * Gets an HLS subtitle playlist.
+	 *
+	 * @param itemId The item id.
+	 * @param index The subtitle stream index.
+	 * @param mediaSourceId The media source id.
+	 * @param segmentLength The subtitle segment length.
+	 */
+	fun getSubtitlePlaylistUrl(
+		itemId: UUID,
+		index: Int,
+		mediaSourceId: String,
+		segmentLength: Int
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["index"] = index
+		pathParameters["mediaSourceId"] = mediaSourceId
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["segmentLength"] = segmentLength
+		return api.createUrl("/Videos/{itemId}/{mediaSourceId}/Subtitles/{index}/subtitles.m3u8",
+				pathParameters, queryParameters)
+	}
+
+	/**
 	 * Deletes an external subtitle file.
 	 *
 	 * @param itemId The item id.

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/UniversalAudioApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/UniversalAudioApi.kt
@@ -106,6 +106,69 @@ class UniversalAudioApi(
 	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
 	 * @param enableRedirection Whether to enable redirection. Defaults to true.
 	 */
+	fun getUniversalAudioStreamUrl(
+		itemId: UUID,
+		container: String,
+		mediaSourceId: String? = null,
+		deviceId: String? = null,
+		userId: UUID? = null,
+		audioCodec: String? = null,
+		maxAudioChannels: Int? = null,
+		transcodingAudioChannels: Int? = null,
+		maxStreamingBitrate: Long? = null,
+		startTimeTicks: Long? = null,
+		transcodingContainer: String? = null,
+		transcodingProtocol: String? = null,
+		maxAudioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		enableRemoteMedia: Boolean? = null,
+		breakOnNonKeyFrames: Boolean,
+		enableRedirection: Boolean
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["container"] = container
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["userId"] = userId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["transcodingAudioChannels"] = transcodingAudioChannels
+		queryParameters["maxStreamingBitrate"] = maxStreamingBitrate
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["transcodingContainer"] = transcodingContainer
+		queryParameters["transcodingProtocol"] = transcodingProtocol
+		queryParameters["maxAudioSampleRate"] = maxAudioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["enableRemoteMedia"] = enableRemoteMedia
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["enableRedirection"] = enableRedirection
+		return api.createUrl("/Audio/{itemId}/universal", pathParameters, queryParameters)
+	}
+
+	/**
+	 * Gets an audio stream.
+	 *
+	 * @param itemId The item id.
+	 * @param container Optional. The audio container.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param userId Optional. The user id.
+	 * @param audioCodec Optional. The audio codec to transcode to.
+	 * @param maxAudioChannels Optional. The maximum number of audio channels.
+	 * @param transcodingAudioChannels Optional. The number of how many audio channels to transcode to.
+	 * @param maxStreamingBitrate Optional. The maximum streaming bitrate.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param transcodingContainer Optional. The container to transcode to.
+	 * @param transcodingProtocol Optional. The transcoding protocol.
+	 * @param maxAudioSampleRate Optional. The maximum audio sample rate.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param enableRemoteMedia Optional. Whether to enable remote media.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param enableRedirection Whether to enable redirection. Defaults to true.
+	 */
 	suspend fun getUniversalAudioStream_2(
 		itemId: UUID,
 		container: String,
@@ -148,5 +211,68 @@ class UniversalAudioApi(
 		val response = api.get<InputStream>("/Audio/{itemId}/universal.{container}", pathParameters,
 				queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Gets an audio stream.
+	 *
+	 * @param itemId The item id.
+	 * @param container Optional. The audio container.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param userId Optional. The user id.
+	 * @param audioCodec Optional. The audio codec to transcode to.
+	 * @param maxAudioChannels Optional. The maximum number of audio channels.
+	 * @param transcodingAudioChannels Optional. The number of how many audio channels to transcode to.
+	 * @param maxStreamingBitrate Optional. The maximum streaming bitrate.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param transcodingContainer Optional. The container to transcode to.
+	 * @param transcodingProtocol Optional. The transcoding protocol.
+	 * @param maxAudioSampleRate Optional. The maximum audio sample rate.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param enableRemoteMedia Optional. Whether to enable remote media.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param enableRedirection Whether to enable redirection. Defaults to true.
+	 */
+	fun getUniversalAudioStream_2Url(
+		itemId: UUID,
+		container: String,
+		mediaSourceId: String? = null,
+		deviceId: String? = null,
+		userId: UUID? = null,
+		audioCodec: String? = null,
+		maxAudioChannels: Int? = null,
+		transcodingAudioChannels: Int? = null,
+		maxStreamingBitrate: Long? = null,
+		startTimeTicks: Long? = null,
+		transcodingContainer: String? = null,
+		transcodingProtocol: String? = null,
+		maxAudioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		enableRemoteMedia: Boolean? = null,
+		breakOnNonKeyFrames: Boolean,
+		enableRedirection: Boolean
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["container"] = container
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["userId"] = userId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["transcodingAudioChannels"] = transcodingAudioChannels
+		queryParameters["maxStreamingBitrate"] = maxStreamingBitrate
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["transcodingContainer"] = transcodingContainer
+		queryParameters["transcodingProtocol"] = transcodingProtocol
+		queryParameters["maxAudioSampleRate"] = maxAudioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["enableRemoteMedia"] = enableRemoteMedia
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["enableRedirection"] = enableRedirection
+		return api.createUrl("/Audio/{itemId}/universal.{container}", pathParameters, queryParameters)
 	}
 }

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideoAttachmentsApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideoAttachmentsApi.kt
@@ -38,4 +38,25 @@ class VideoAttachmentsApi(
 				pathParameters, queryParameters, data)
 		return response
 	}
+
+	/**
+	 * Get video attachment.
+	 *
+	 * @param videoId Video ID.
+	 * @param mediaSourceId Media Source ID.
+	 * @param index Attachment Index.
+	 */
+	fun getAttachmentUrl(
+		videoId: UUID,
+		mediaSourceId: String,
+		index: Int
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["videoId"] = videoId
+		pathParameters["mediaSourceId"] = mediaSourceId
+		pathParameters["index"] = index
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/Videos/{videoId}/{mediaSourceId}/Attachments/{index}", pathParameters,
+				queryParameters)
+	}
 }

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideoHlsApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideoHlsApi.kt
@@ -206,4 +206,186 @@ class VideoHlsApi(
 				data)
 		return response
 	}
+
+	/**
+	 * Gets a hls live stream.
+	 *
+	 * @param itemId The item id.
+	 * @param container The audio container.
+	 * @param static Optional. If true, the original file will be streamed statically without any
+	 * encoding. Use either no url extension or the original file extension. true/false.
+	 * @param params The streaming parameters.
+	 * @param tag The tag.
+	 * @param deviceProfileId Optional. The dlna device profile id to utilize.
+	 * @param playSessionId The play session id.
+	 * @param segmentContainer The segment container.
+	 * @param segmentLength The segment lenght.
+	 * @param minSegments The minimum number of segments.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param audioCodec Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server
+	 * will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.
+	 * @param enableAutoStreamCopy Whether or not to allow automatic stream copy if requested values
+	 * match the original source. Defaults to true.
+	 * @param allowVideoStreamCopy Whether or not to allow copying of the video stream url.
+	 * @param allowAudioStreamCopy Whether or not to allow copying of the audio stream url.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param audioSampleRate Optional. Specify a specific audio sample rate, e.g. 44100.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param audioBitRate Optional. Specify an audio bitrate to encode to, e.g. 128000. If omitted
+	 * this will be left to encoder defaults.
+	 * @param audioChannels Optional. Specify a specific number of audio channels to encode to, e.g. 2.
+	 * @param maxAudioChannels Optional. Specify a maximum number of audio channels to encode to, e.g.
+	 * 2.
+	 * @param profile Optional. Specify a specific an encoder profile (varies by encoder), e.g. main,
+	 * baseline, high.
+	 * @param level Optional. Specify a level for the encoder profile (varies by encoder), e.g. 3, 3.1.
+	 * @param framerate Optional. A specific video framerate to encode to, e.g. 23.976. Generally this
+	 * should be omitted unless the device has specific requirements.
+	 * @param maxFramerate Optional. A specific maximum video framerate to encode to, e.g. 23.976.
+	 * Generally this should be omitted unless the device has specific requirements.
+	 * @param copyTimestamps Whether or not to copy timestamps when transcoding with an offset.
+	 * Defaults to false.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param width Optional. The fixed horizontal resolution of the encoded video.
+	 * @param height Optional. The fixed vertical resolution of the encoded video.
+	 * @param videoBitRate Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this
+	 * will be left to encoder defaults.
+	 * @param subtitleStreamIndex Optional. The index of the subtitle stream to use. If omitted no
+	 * subtitles will be used.
+	 * @param subtitleMethod Optional. Specify the subtitle delivery method.
+	 * @param maxRefFrames Optional.
+	 * @param maxVideoBitDepth Optional. The maximum video bit depth.
+	 * @param requireAvc Optional. Whether to require avc.
+	 * @param deInterlace Optional. Whether to deinterlace the video.
+	 * @param requireNonAnamorphic Optional. Whether to require a non anamporphic stream.
+	 * @param transcodingMaxAudioChannels Optional. The maximum number of audio channels to transcode.
+	 * @param cpuCoreLimit Optional. The limit of how many cpu cores to use.
+	 * @param liveStreamId The live stream id.
+	 * @param enableMpegtsM2TsMode Optional. Whether to enable the MpegtsM2Ts mode.
+	 * @param videoCodec Optional. Specify a video codec to encode to, e.g. h264. If omitted the server
+	 * will auto-select using the url's extension. Options: h265, h264, mpeg4, theora, vpx, wmv.
+	 * @param subtitleCodec Optional. Specify a subtitle codec to encode to.
+	 * @param transcodingReasons Optional. The transcoding reason.
+	 * @param audioStreamIndex Optional. The index of the audio stream to use. If omitted the first
+	 * audio stream will be used.
+	 * @param videoStreamIndex Optional. The index of the video stream to use. If omitted the first
+	 * video stream will be used.
+	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
+	 * @param streamOptions Optional. The streaming options.
+	 * @param maxWidth Optional. The max width.
+	 * @param maxHeight Optional. The max height.
+	 * @param enableSubtitlesInManifest Optional. Whether to enable subtitles in the manifest.
+	 */
+	fun getLiveHlsStreamUrl(
+		itemId: UUID,
+		container: String? = null,
+		static: Boolean? = null,
+		params: String? = null,
+		tag: String? = null,
+		deviceProfileId: String? = null,
+		playSessionId: String? = null,
+		segmentContainer: String? = null,
+		segmentLength: Int? = null,
+		minSegments: Int? = null,
+		mediaSourceId: String? = null,
+		deviceId: String? = null,
+		audioCodec: String? = null,
+		enableAutoStreamCopy: Boolean? = null,
+		allowVideoStreamCopy: Boolean? = null,
+		allowAudioStreamCopy: Boolean? = null,
+		breakOnNonKeyFrames: Boolean? = null,
+		audioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		audioBitRate: Int? = null,
+		audioChannels: Int? = null,
+		maxAudioChannels: Int? = null,
+		profile: String? = null,
+		level: String? = null,
+		framerate: Float? = null,
+		maxFramerate: Float? = null,
+		copyTimestamps: Boolean? = null,
+		startTimeTicks: Long? = null,
+		width: Int? = null,
+		height: Int? = null,
+		videoBitRate: Int? = null,
+		subtitleStreamIndex: Int? = null,
+		subtitleMethod: SubtitleDeliveryMethod,
+		maxRefFrames: Int? = null,
+		maxVideoBitDepth: Int? = null,
+		requireAvc: Boolean? = null,
+		deInterlace: Boolean? = null,
+		requireNonAnamorphic: Boolean? = null,
+		transcodingMaxAudioChannels: Int? = null,
+		cpuCoreLimit: Int? = null,
+		liveStreamId: String? = null,
+		enableMpegtsM2TsMode: Boolean? = null,
+		videoCodec: String? = null,
+		subtitleCodec: String? = null,
+		transcodingReasons: String? = null,
+		audioStreamIndex: Int? = null,
+		videoStreamIndex: Int? = null,
+		context: EncodingContext,
+		streamOptions: Map<String, String>? = null,
+		maxWidth: Int? = null,
+		maxHeight: Int? = null,
+		enableSubtitlesInManifest: Boolean? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["container"] = container
+		queryParameters["static"] = static
+		queryParameters["params"] = params
+		queryParameters["tag"] = tag
+		queryParameters["deviceProfileId"] = deviceProfileId
+		queryParameters["playSessionId"] = playSessionId
+		queryParameters["segmentContainer"] = segmentContainer
+		queryParameters["segmentLength"] = segmentLength
+		queryParameters["minSegments"] = minSegments
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
+		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
+		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["audioSampleRate"] = audioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["audioBitRate"] = audioBitRate
+		queryParameters["audioChannels"] = audioChannels
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["profile"] = profile
+		queryParameters["level"] = level
+		queryParameters["framerate"] = framerate
+		queryParameters["maxFramerate"] = maxFramerate
+		queryParameters["copyTimestamps"] = copyTimestamps
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["videoBitRate"] = videoBitRate
+		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
+		queryParameters["subtitleMethod"] = subtitleMethod
+		queryParameters["maxRefFrames"] = maxRefFrames
+		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
+		queryParameters["requireAvc"] = requireAvc
+		queryParameters["deInterlace"] = deInterlace
+		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
+		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
+		queryParameters["cpuCoreLimit"] = cpuCoreLimit
+		queryParameters["liveStreamId"] = liveStreamId
+		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
+		queryParameters["videoCodec"] = videoCodec
+		queryParameters["subtitleCodec"] = subtitleCodec
+		queryParameters["transcodingReasons"] = transcodingReasons
+		queryParameters["audioStreamIndex"] = audioStreamIndex
+		queryParameters["videoStreamIndex"] = videoStreamIndex
+		queryParameters["context"] = context
+		queryParameters["streamOptions"] = streamOptions
+		queryParameters["maxWidth"] = maxWidth
+		queryParameters["maxHeight"] = maxHeight
+		queryParameters["enableSubtitlesInManifest"] = enableSubtitlesInManifest
+		return api.createUrl("/Videos/{itemId}/live.m3u8", pathParameters, queryParameters)
+	}
 }

--- a/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideosApi.kt
+++ b/api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideosApi.kt
@@ -204,6 +204,182 @@ class VideosApi(
 	}
 
 	/**
+	 * Gets a video stream.
+	 *
+	 * @param itemId The item id.
+	 * @param container The video container. Possible values are: ts, webm, asf, wmv, ogv, mp4, m4v,
+	 * mkv, mpeg, mpg, avi, 3gp, wmv, wtv, m2ts, mov, iso, flv.
+	 * @param static Optional. If true, the original file will be streamed statically without any
+	 * encoding. Use either no url extension or the original file extension. true/false.
+	 * @param params The streaming parameters.
+	 * @param tag The tag.
+	 * @param deviceProfileId Optional. The dlna device profile id to utilize.
+	 * @param playSessionId The play session id.
+	 * @param segmentContainer The segment container.
+	 * @param segmentLength The segment lenght.
+	 * @param minSegments The minimum number of segments.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param audioCodec Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server
+	 * will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.
+	 * @param enableAutoStreamCopy Whether or not to allow automatic stream copy if requested values
+	 * match the original source. Defaults to true.
+	 * @param allowVideoStreamCopy Whether or not to allow copying of the video stream url.
+	 * @param allowAudioStreamCopy Whether or not to allow copying of the audio stream url.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param audioSampleRate Optional. Specify a specific audio sample rate, e.g. 44100.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param audioBitRate Optional. Specify an audio bitrate to encode to, e.g. 128000. If omitted
+	 * this will be left to encoder defaults.
+	 * @param audioChannels Optional. Specify a specific number of audio channels to encode to, e.g. 2.
+	 * @param maxAudioChannels Optional. Specify a maximum number of audio channels to encode to, e.g.
+	 * 2.
+	 * @param profile Optional. Specify a specific an encoder profile (varies by encoder), e.g. main,
+	 * baseline, high.
+	 * @param level Optional. Specify a level for the encoder profile (varies by encoder), e.g. 3, 3.1.
+	 * @param framerate Optional. A specific video framerate to encode to, e.g. 23.976. Generally this
+	 * should be omitted unless the device has specific requirements.
+	 * @param maxFramerate Optional. A specific maximum video framerate to encode to, e.g. 23.976.
+	 * Generally this should be omitted unless the device has specific requirements.
+	 * @param copyTimestamps Whether or not to copy timestamps when transcoding with an offset.
+	 * Defaults to false.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param width Optional. The fixed horizontal resolution of the encoded video.
+	 * @param height Optional. The fixed vertical resolution of the encoded video.
+	 * @param videoBitRate Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this
+	 * will be left to encoder defaults.
+	 * @param subtitleStreamIndex Optional. The index of the subtitle stream to use. If omitted no
+	 * subtitles will be used.
+	 * @param subtitleMethod Optional. Specify the subtitle delivery method.
+	 * @param maxRefFrames Optional.
+	 * @param maxVideoBitDepth Optional. The maximum video bit depth.
+	 * @param requireAvc Optional. Whether to require avc.
+	 * @param deInterlace Optional. Whether to deinterlace the video.
+	 * @param requireNonAnamorphic Optional. Whether to require a non anamporphic stream.
+	 * @param transcodingMaxAudioChannels Optional. The maximum number of audio channels to transcode.
+	 * @param cpuCoreLimit Optional. The limit of how many cpu cores to use.
+	 * @param liveStreamId The live stream id.
+	 * @param enableMpegtsM2TsMode Optional. Whether to enable the MpegtsM2Ts mode.
+	 * @param videoCodec Optional. Specify a video codec to encode to, e.g. h264. If omitted the server
+	 * will auto-select using the url's extension. Options: h265, h264, mpeg4, theora, vpx, wmv.
+	 * @param subtitleCodec Optional. Specify a subtitle codec to encode to.
+	 * @param transcodingReasons Optional. The transcoding reason.
+	 * @param audioStreamIndex Optional. The index of the audio stream to use. If omitted the first
+	 * audio stream will be used.
+	 * @param videoStreamIndex Optional. The index of the video stream to use. If omitted the first
+	 * video stream will be used.
+	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
+	 * @param streamOptions Optional. The streaming options.
+	 */
+	fun getVideoStream_2Url(
+		itemId: UUID,
+		container: String,
+		stream: String,
+		static: Boolean? = null,
+		params: String? = null,
+		tag: String? = null,
+		deviceProfileId: String? = null,
+		playSessionId: String? = null,
+		segmentContainer: String? = null,
+		segmentLength: Int? = null,
+		minSegments: Int? = null,
+		mediaSourceId: String? = null,
+		deviceId: String? = null,
+		audioCodec: String? = null,
+		enableAutoStreamCopy: Boolean? = null,
+		allowVideoStreamCopy: Boolean? = null,
+		allowAudioStreamCopy: Boolean? = null,
+		breakOnNonKeyFrames: Boolean? = null,
+		audioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		audioBitRate: Int? = null,
+		audioChannels: Int? = null,
+		maxAudioChannels: Int? = null,
+		profile: String? = null,
+		level: String? = null,
+		framerate: Float? = null,
+		maxFramerate: Float? = null,
+		copyTimestamps: Boolean? = null,
+		startTimeTicks: Long? = null,
+		width: Int? = null,
+		height: Int? = null,
+		videoBitRate: Int? = null,
+		subtitleStreamIndex: Int? = null,
+		subtitleMethod: SubtitleDeliveryMethod,
+		maxRefFrames: Int? = null,
+		maxVideoBitDepth: Int? = null,
+		requireAvc: Boolean? = null,
+		deInterlace: Boolean? = null,
+		requireNonAnamorphic: Boolean? = null,
+		transcodingMaxAudioChannels: Int? = null,
+		cpuCoreLimit: Int? = null,
+		liveStreamId: String? = null,
+		enableMpegtsM2TsMode: Boolean? = null,
+		videoCodec: String? = null,
+		subtitleCodec: String? = null,
+		transcodingReasons: String? = null,
+		audioStreamIndex: Int? = null,
+		videoStreamIndex: Int? = null,
+		context: EncodingContext,
+		streamOptions: Map<String, String>? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["container"] = container
+		pathParameters["stream"] = stream
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["static"] = static
+		queryParameters["params"] = params
+		queryParameters["tag"] = tag
+		queryParameters["deviceProfileId"] = deviceProfileId
+		queryParameters["playSessionId"] = playSessionId
+		queryParameters["segmentContainer"] = segmentContainer
+		queryParameters["segmentLength"] = segmentLength
+		queryParameters["minSegments"] = minSegments
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
+		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
+		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["audioSampleRate"] = audioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["audioBitRate"] = audioBitRate
+		queryParameters["audioChannels"] = audioChannels
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["profile"] = profile
+		queryParameters["level"] = level
+		queryParameters["framerate"] = framerate
+		queryParameters["maxFramerate"] = maxFramerate
+		queryParameters["copyTimestamps"] = copyTimestamps
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["videoBitRate"] = videoBitRate
+		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
+		queryParameters["subtitleMethod"] = subtitleMethod
+		queryParameters["maxRefFrames"] = maxRefFrames
+		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
+		queryParameters["requireAvc"] = requireAvc
+		queryParameters["deInterlace"] = deInterlace
+		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
+		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
+		queryParameters["cpuCoreLimit"] = cpuCoreLimit
+		queryParameters["liveStreamId"] = liveStreamId
+		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
+		queryParameters["videoCodec"] = videoCodec
+		queryParameters["subtitleCodec"] = subtitleCodec
+		queryParameters["transcodingReasons"] = transcodingReasons
+		queryParameters["audioStreamIndex"] = audioStreamIndex
+		queryParameters["videoStreamIndex"] = videoStreamIndex
+		queryParameters["context"] = context
+		queryParameters["streamOptions"] = streamOptions
+		return api.createUrl("/Videos/{itemId}/{stream}.{container}", pathParameters, queryParameters)
+	}
+
+	/**
 	 * Gets additional parts for a video.
 	 *
 	 * @param itemId The item id.
@@ -411,6 +587,180 @@ class VideosApi(
 		val response = api.get<InputStream>("/Videos/{itemId}/stream", pathParameters, queryParameters,
 				data)
 		return response
+	}
+
+	/**
+	 * Gets a video stream.
+	 *
+	 * @param itemId The item id.
+	 * @param container The video container. Possible values are: ts, webm, asf, wmv, ogv, mp4, m4v,
+	 * mkv, mpeg, mpg, avi, 3gp, wmv, wtv, m2ts, mov, iso, flv.
+	 * @param static Optional. If true, the original file will be streamed statically without any
+	 * encoding. Use either no url extension or the original file extension. true/false.
+	 * @param params The streaming parameters.
+	 * @param tag The tag.
+	 * @param deviceProfileId Optional. The dlna device profile id to utilize.
+	 * @param playSessionId The play session id.
+	 * @param segmentContainer The segment container.
+	 * @param segmentLength The segment lenght.
+	 * @param minSegments The minimum number of segments.
+	 * @param mediaSourceId The media version id, if playing an alternate version.
+	 * @param deviceId The device id of the client requesting. Used to stop encoding processes when
+	 * needed.
+	 * @param audioCodec Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server
+	 * will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.
+	 * @param enableAutoStreamCopy Whether or not to allow automatic stream copy if requested values
+	 * match the original source. Defaults to true.
+	 * @param allowVideoStreamCopy Whether or not to allow copying of the video stream url.
+	 * @param allowAudioStreamCopy Whether or not to allow copying of the audio stream url.
+	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
+	 * @param audioSampleRate Optional. Specify a specific audio sample rate, e.g. 44100.
+	 * @param maxAudioBitDepth Optional. The maximum audio bit depth.
+	 * @param audioBitRate Optional. Specify an audio bitrate to encode to, e.g. 128000. If omitted
+	 * this will be left to encoder defaults.
+	 * @param audioChannels Optional. Specify a specific number of audio channels to encode to, e.g. 2.
+	 * @param maxAudioChannels Optional. Specify a maximum number of audio channels to encode to, e.g.
+	 * 2.
+	 * @param profile Optional. Specify a specific an encoder profile (varies by encoder), e.g. main,
+	 * baseline, high.
+	 * @param level Optional. Specify a level for the encoder profile (varies by encoder), e.g. 3, 3.1.
+	 * @param framerate Optional. A specific video framerate to encode to, e.g. 23.976. Generally this
+	 * should be omitted unless the device has specific requirements.
+	 * @param maxFramerate Optional. A specific maximum video framerate to encode to, e.g. 23.976.
+	 * Generally this should be omitted unless the device has specific requirements.
+	 * @param copyTimestamps Whether or not to copy timestamps when transcoding with an offset.
+	 * Defaults to false.
+	 * @param startTimeTicks Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.
+	 * @param width Optional. The fixed horizontal resolution of the encoded video.
+	 * @param height Optional. The fixed vertical resolution of the encoded video.
+	 * @param videoBitRate Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this
+	 * will be left to encoder defaults.
+	 * @param subtitleStreamIndex Optional. The index of the subtitle stream to use. If omitted no
+	 * subtitles will be used.
+	 * @param subtitleMethod Optional. Specify the subtitle delivery method.
+	 * @param maxRefFrames Optional.
+	 * @param maxVideoBitDepth Optional. The maximum video bit depth.
+	 * @param requireAvc Optional. Whether to require avc.
+	 * @param deInterlace Optional. Whether to deinterlace the video.
+	 * @param requireNonAnamorphic Optional. Whether to require a non anamporphic stream.
+	 * @param transcodingMaxAudioChannels Optional. The maximum number of audio channels to transcode.
+	 * @param cpuCoreLimit Optional. The limit of how many cpu cores to use.
+	 * @param liveStreamId The live stream id.
+	 * @param enableMpegtsM2TsMode Optional. Whether to enable the MpegtsM2Ts mode.
+	 * @param videoCodec Optional. Specify a video codec to encode to, e.g. h264. If omitted the server
+	 * will auto-select using the url's extension. Options: h265, h264, mpeg4, theora, vpx, wmv.
+	 * @param subtitleCodec Optional. Specify a subtitle codec to encode to.
+	 * @param transcodingReasons Optional. The transcoding reason.
+	 * @param audioStreamIndex Optional. The index of the audio stream to use. If omitted the first
+	 * audio stream will be used.
+	 * @param videoStreamIndex Optional. The index of the video stream to use. If omitted the first
+	 * video stream will be used.
+	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
+	 * @param streamOptions Optional. The streaming options.
+	 */
+	fun getVideoStreamUrl(
+		itemId: UUID,
+		container: String,
+		static: Boolean? = null,
+		params: String? = null,
+		tag: String? = null,
+		deviceProfileId: String? = null,
+		playSessionId: String? = null,
+		segmentContainer: String? = null,
+		segmentLength: Int? = null,
+		minSegments: Int? = null,
+		mediaSourceId: String? = null,
+		deviceId: String? = null,
+		audioCodec: String? = null,
+		enableAutoStreamCopy: Boolean? = null,
+		allowVideoStreamCopy: Boolean? = null,
+		allowAudioStreamCopy: Boolean? = null,
+		breakOnNonKeyFrames: Boolean? = null,
+		audioSampleRate: Int? = null,
+		maxAudioBitDepth: Int? = null,
+		audioBitRate: Int? = null,
+		audioChannels: Int? = null,
+		maxAudioChannels: Int? = null,
+		profile: String? = null,
+		level: String? = null,
+		framerate: Float? = null,
+		maxFramerate: Float? = null,
+		copyTimestamps: Boolean? = null,
+		startTimeTicks: Long? = null,
+		width: Int? = null,
+		height: Int? = null,
+		videoBitRate: Int? = null,
+		subtitleStreamIndex: Int? = null,
+		subtitleMethod: SubtitleDeliveryMethod,
+		maxRefFrames: Int? = null,
+		maxVideoBitDepth: Int? = null,
+		requireAvc: Boolean? = null,
+		deInterlace: Boolean? = null,
+		requireNonAnamorphic: Boolean? = null,
+		transcodingMaxAudioChannels: Int? = null,
+		cpuCoreLimit: Int? = null,
+		liveStreamId: String? = null,
+		enableMpegtsM2TsMode: Boolean? = null,
+		videoCodec: String? = null,
+		subtitleCodec: String? = null,
+		transcodingReasons: String? = null,
+		audioStreamIndex: Int? = null,
+		videoStreamIndex: Int? = null,
+		context: EncodingContext,
+		streamOptions: Map<String, String>? = null
+	): String {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		pathParameters["container"] = container
+		val queryParameters = mutableMapOf<String, Any?>()
+		queryParameters["static"] = static
+		queryParameters["params"] = params
+		queryParameters["tag"] = tag
+		queryParameters["deviceProfileId"] = deviceProfileId
+		queryParameters["playSessionId"] = playSessionId
+		queryParameters["segmentContainer"] = segmentContainer
+		queryParameters["segmentLength"] = segmentLength
+		queryParameters["minSegments"] = minSegments
+		queryParameters["mediaSourceId"] = mediaSourceId
+		queryParameters["deviceId"] = deviceId
+		queryParameters["audioCodec"] = audioCodec
+		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
+		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
+		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
+		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
+		queryParameters["audioSampleRate"] = audioSampleRate
+		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
+		queryParameters["audioBitRate"] = audioBitRate
+		queryParameters["audioChannels"] = audioChannels
+		queryParameters["maxAudioChannels"] = maxAudioChannels
+		queryParameters["profile"] = profile
+		queryParameters["level"] = level
+		queryParameters["framerate"] = framerate
+		queryParameters["maxFramerate"] = maxFramerate
+		queryParameters["copyTimestamps"] = copyTimestamps
+		queryParameters["startTimeTicks"] = startTimeTicks
+		queryParameters["width"] = width
+		queryParameters["height"] = height
+		queryParameters["videoBitRate"] = videoBitRate
+		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
+		queryParameters["subtitleMethod"] = subtitleMethod
+		queryParameters["maxRefFrames"] = maxRefFrames
+		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
+		queryParameters["requireAvc"] = requireAvc
+		queryParameters["deInterlace"] = deInterlace
+		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
+		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
+		queryParameters["cpuCoreLimit"] = cpuCoreLimit
+		queryParameters["liveStreamId"] = liveStreamId
+		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
+		queryParameters["videoCodec"] = videoCodec
+		queryParameters["subtitleCodec"] = subtitleCodec
+		queryParameters["transcodingReasons"] = transcodingReasons
+		queryParameters["audioStreamIndex"] = audioStreamIndex
+		queryParameters["videoStreamIndex"] = videoStreamIndex
+		queryParameters["context"] = context
+		queryParameters["streamOptions"] = streamOptions
+		return api.createUrl("/Videos/{itemId}/stream", pathParameters, queryParameters)
 	}
 
 	/**

--- a/api/src/main/kotlin/org/jellyfin/apiclient/api/client/ApiClient.kt
+++ b/api/src/main/kotlin/org/jellyfin/apiclient/api/client/ApiClient.kt
@@ -1,0 +1,26 @@
+package org.jellyfin.apiclient.api.client
+
+interface ApiClient {
+	var baseUrl: String?
+
+	/**
+	 * Replaces the variables in a path with the values in the map.
+	 * Will also remove trailing and repeated slashes
+	 */
+	fun createPath(
+		path: String,
+		pathParameters: Map<String, Any?> = emptyMap()
+	): String
+
+	/**
+	 * Create a complete url based on the [baseUrl] and given parameters.
+	 * Uses [createPath] to create the path
+	 */
+	fun createUrl(
+		pathTemplate: String,
+		pathParameters: Map<String, Any?> = emptyMap(),
+		queryParameters: Map<String, Any?> = emptyMap(),
+	): String
+
+	fun createAuthorizationHeader(): String?
+}

--- a/api/src/main/kotlin/org/jellyfin/apiclient/api/client/KtorClient.kt
+++ b/api/src/main/kotlin/org/jellyfin/apiclient/api/client/KtorClient.kt
@@ -17,7 +17,7 @@ open class KtorClient(
 	var accessToken: String? = null,
 	var clientInfo: ClientInfo,
 	var deviceInfo: DeviceInfo
-): ApiClient {
+) : ApiClient {
 	val client = HttpClient {
 		install(JsonFeature) {
 			serializer = KotlinxSerializer()
@@ -104,15 +104,15 @@ open class KtorClient(
 		pathTemplate: String,
 		pathParameters: Map<String, Any?> = emptyMap(),
 		queryParameters: Map<String, Any?> = emptyMap(),
-		body: Any? = null
+		requestBody: Any? = null
 	): Response<T> {
 		val response = client.request<HttpResponse> {
 			this.method = method
 			url(createUrl(pathTemplate, pathParameters, queryParameters))
 			header(HttpHeaders.Authorization, createAuthorizationHeader())
 
-			if (body != null)
-				this.body = defaultSerializer().write(body)
+			if (requestBody != null)
+				body = defaultSerializer().write(requestBody)
 		}
 
 		return Response(response.receive())
@@ -122,38 +122,38 @@ open class KtorClient(
 		pathTemplate: String,
 		pathParameters: Map<String, Any?> = emptyMap(),
 		queryParameters: Map<String, Any?> = emptyMap(),
-		body: Any? = null
+		requestBody: Any? = null
 	) = request<T>(
 		method = HttpMethod.Get,
 		pathTemplate = pathTemplate,
 		pathParameters = pathParameters,
 		queryParameters = queryParameters,
-		body = body
+		requestBody = requestBody
 	)
 
 	suspend inline fun <reified T> post(
 		pathTemplate: String,
 		pathParameters: Map<String, Any?> = emptyMap(),
 		queryParameters: Map<String, Any?> = emptyMap(),
-		body: Any? = null
+		requestBody: Any? = null
 	) = request<T>(
 		method = HttpMethod.Post,
 		pathTemplate = pathTemplate,
 		pathParameters = pathParameters,
 		queryParameters = queryParameters,
-		body = body
+		requestBody = requestBody
 	)
 
 	suspend inline fun <reified T> delete(
 		pathTemplate: String,
 		pathParameters: Map<String, Any?> = emptyMap(),
 		queryParameters: Map<String, Any?> = emptyMap(),
-		body: Any? = null
+		requestBody: Any? = null
 	) = request<T>(
 		method = HttpMethod.Delete,
 		pathTemplate = pathTemplate,
 		pathParameters = pathParameters,
 		queryParameters = queryParameters,
-		body = body
+		requestBody = requestBody
 	)
 }

--- a/api/src/main/kotlin/org/jellyfin/apiclient/api/client/KtorClient.kt
+++ b/api/src/main/kotlin/org/jellyfin/apiclient/api/client/KtorClient.kt
@@ -13,11 +13,11 @@ import org.jellyfin.apiclient.model.DeviceInfo
 import kotlin.collections.set
 
 open class KtorClient(
-	var baseUrl: String? = null,
+	override var baseUrl: String? = null,
 	var accessToken: String? = null,
 	var clientInfo: ClientInfo,
 	var deviceInfo: DeviceInfo
-) {
+): ApiClient {
 	val client = HttpClient {
 		install(JsonFeature) {
 			serializer = KotlinxSerializer()
@@ -28,11 +28,7 @@ open class KtorClient(
 		}
 	}
 
-	/**
-	 * Replaces the variables in a path with the values in the map.
-	 * Will also remove trailing and repeated slashes
-	 */
-	fun createPath(path: String, pathParameters: Map<String, Any?>) = path
+	override fun createPath(path: String, pathParameters: Map<String, Any?>) = path
 		.split('/')
 		.filterNot { it.isEmpty() }
 		.map { rawName ->
@@ -48,7 +44,33 @@ open class KtorClient(
 		}
 		.joinToString("/")
 
-	fun createAuthorizationHeader(): String? {
+	override fun createUrl(
+		pathTemplate: String,
+		pathParameters: Map<String, Any?>,
+		queryParameters: Map<String, Any?>,
+	): String {
+		// Check if the base url is not null
+		val baseUrl = checkNotNull(baseUrl)
+
+		return URLBuilder(baseUrl).apply {
+			// Create from base URL
+			takeFrom(baseUrl)
+
+			// Replace path variables
+			val path = createPath(pathTemplate, pathParameters)
+			// Assign path making sure to remove duplicated slashes between the base and appended path
+			encodedPath = "${encodedPath.trimEnd('/')}/${path.trimStart('/')}"
+
+			// Append query parameters
+			queryParameters
+				.filterNot { it.value == null }
+				.forEach {
+					parameters.append(it.key, it.value.toString())
+				}
+		}.buildString()
+	}
+
+	override fun createAuthorizationHeader(): String? {
 		val params = mutableMapOf(
 			"client" to clientInfo.name,
 			"version" to clientInfo.version,
@@ -84,34 +106,13 @@ open class KtorClient(
 		queryParameters: Map<String, Any?> = emptyMap(),
 		body: Any? = null
 	): Response<T> {
-		// Check if the base url is not null
-		val baseUrl = checkNotNull(baseUrl)
-
 		val response = client.request<HttpResponse> {
 			this.method = method
-
-			url {
-				// Create from base URL
-				takeFrom(baseUrl)
-
-				// Replace path variables
-				val path = createPath(pathTemplate, pathParameters)
-				// Assign path making sure to remove duplicated slashes between the base and appended path
-				encodedPath = "${encodedPath.trimEnd('/')}/${path.trimStart('/')}"
-
-				// Append query parameters
-				queryParameters
-					.filterNot { it.value == null }
-					.forEach {
-						parameters.append(it.key, it.value.toString())
-					}
-			}
-
+			url(createUrl(pathTemplate, pathParameters, queryParameters))
 			header(HttpHeaders.Authorization, createAuthorizationHeader())
 
-			if (body != null) {
+			if (body != null)
 				this.body = defaultSerializer().write(body)
-			}
 		}
 
 		return Response(response.receive())

--- a/openapi-generator/README.md
+++ b/openapi-generator/README.md
@@ -18,13 +18,19 @@ Hooks are classes that will modify the output of the generator. They should be r
 
 - **TypeBuilderHook**  
   A hook that can intercept the TypeBuilder which converts OpenAPI schemas to Kotlin types. It
-   receives the schema and a type path. The path is unique across the whole document and can be used
-   to identified specific properties. This hook is called when generating types for:
+  receives the schema and a type path. The path is unique across the whole document and can be used
+  to identified specific properties. This hook is called when generating types for:
    
-   - model properties
-   - api operation parameters
-   - api operation bodies
-   - api operation return types
+  - model properties
+  - api operation parameters
+  - api operation bodies
+  - api operation return types
+
+- **OperationUrlHook**
+  A hook that can request a url function to be added for an API operation. It receives the model for
+  a complete api service and a single operation. If any hook returns `true` the generator will add
+  a special function called `[operation]Url` (like "GetImageUrl") that will return a string
+  containing the request url. 
 
 ## Phases
 

--- a/openapi-generator/README.md
+++ b/openapi-generator/README.md
@@ -16,21 +16,21 @@ OpenAPI specification changes.
 Hooks are classes that will modify the output of the generator. They should be registered in the
 `HookModule.kt` file. The following hooks are available:
 
-- **TypeBuilderHook**  
-  A hook that can intercept the TypeBuilder which converts OpenAPI schemas to Kotlin types. It
-  receives the schema and a type path. The path is unique across the whole document and can be used
-  to identified specific properties. This hook is called when generating types for:
-   
-  - model properties
-  - api operation parameters
-  - api operation bodies
-  - api operation return types
+  - **TypeBuilderHook**  
+    A hook that can intercept the TypeBuilder which converts OpenAPI schemas to Kotlin types. It
+    receives the schema and a type path. The path is unique across the whole document and can be used
+    to identified specific properties. This hook is called when generating types for:
+     
+      - model properties
+      - api operation parameters
+      - api operation bodies
+      - api operation return types
 
-- **OperationUrlHook**
-  A hook that can request a url function to be added for an API operation. It receives the model for
-  a complete api service and a single operation. If any hook returns `true` the generator will add
-  a special function called `[operation]Url` (like "GetImageUrl") that will return a string
-  containing the request url. 
+  - **OperationUrlHook**
+    A hook that can request a url function to be added for an API operation. It receives the model for
+    a complete api service and a single operation. If any hook returns `true` the generator will add
+    a special function called `[operation]Url` (like "GetImageUrl") that will return a string
+    containing the request url. 
 
 ## Phases
 

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/MainModule.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/MainModule.kt
@@ -3,6 +3,7 @@ package org.jellyfin.openapi
 import org.jellyfin.openapi.builder.api.ApiBuilder
 import org.jellyfin.openapi.builder.api.ApiNameBuilder
 import org.jellyfin.openapi.builder.api.OperationBuilder
+import org.jellyfin.openapi.builder.api.OperationUrlBuilder
 import org.jellyfin.openapi.builder.extra.DeprecatedAnnotationSpecBuilder
 import org.jellyfin.openapi.builder.extra.FileSpecBuilder
 import org.jellyfin.openapi.builder.extra.TypeSerializerBuilder
@@ -28,7 +29,8 @@ val mainModule = module {
 	// API
 	single { ApiNameBuilder() }
 	single { OperationBuilder(get()) }
-	single { ApiBuilder(get()) }
+	single { OperationUrlBuilder(get()) }
+	single { ApiBuilder(get(), get(), getAll()) }
 
 	// Models
 	single { ModelBuilder(get(), get(), get()) }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
@@ -78,6 +78,6 @@ class OperationBuilder(
 		)
 
 		// Return response
-		addStatement("return response")
+		addStatement("return·response")
 	}.build()
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
@@ -59,7 +59,7 @@ class OperationUrlBuilder(
 
 		// Call API
 		addStatement(
-			"return api.createUrl(%S, pathParameters, queryParameters)",
+			"return·api.createUrl(%S, pathParameters, queryParameters)",
 			data.pathTemplate
 		)
 	}.build()

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
@@ -1,25 +1,17 @@
 package org.jellyfin.openapi.builder.api
 
-import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
-import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.plusParameter
 import org.jellyfin.openapi.builder.Builder
 import org.jellyfin.openapi.builder.extra.DeprecatedAnnotationSpecBuilder
-import org.jellyfin.openapi.constants.Classes
-import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.model.ApiServiceOperation
 import org.jellyfin.openapi.model.ApiServiceOperationParameter
 
-class OperationBuilder(
+class OperationUrlBuilder(
 	private val deprecatedAnnotationSpecBuilder: DeprecatedAnnotationSpecBuilder
 ) : Builder<ApiServiceOperation, FunSpec> {
-	private fun buildFunctionShell(data: ApiServiceOperation) = FunSpec.builder(data.name).apply {
-		// Make function suspended
-		addModifiers(KModifier.SUSPEND)
-
+	private fun buildFunctionShell(data: ApiServiceOperation) = FunSpec.builder(data.name + "Url").apply {
 		// Add description
 		data.description?.let { addKdoc("%L", it) }
 
@@ -27,7 +19,7 @@ class OperationBuilder(
 		if (data.deprecated) addAnnotation(deprecatedAnnotationSpecBuilder.build(Strings.DEPRECATED_MEMBER))
 
 		// Set return type
-		returns(ClassName(Packages.API_CLIENT, Classes.API_RESPONSE).plusParameter(data.returnType))
+		returns(String::class)
 	}
 
 	private fun buildParameter(data: ApiServiceOperationParameter) = ParameterSpec.builder(data.name, data.type).apply {
@@ -65,19 +57,10 @@ class OperationBuilder(
 		addParameterMapStatements("pathParameters", data.pathParameters)
 		addParameterMapStatements("queryParameters", data.queryParameters)
 
-		// Add request body
-		if (data.bodyType != null) addParameter(ParameterSpec("data", data.bodyType))
-		else addStatement("val data = null")
-
 		// Call API
 		addStatement(
-			"val response = api.%N<%T>(%S, pathParameters, queryParameters, data)",
-			data.method.toString().toLowerCase(),
-			data.returnType,
+			"return api.createUrl(%S, pathParameters, queryParameters)",
 			data.pathTemplate
 		)
-
-		// Return response
-		addStatement("return response")
 	}.build()
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiReturnTypeBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiReturnTypeBuilder.kt
@@ -21,21 +21,27 @@ class OpenApiReturnTypeBuilder(
 			MimeType.TEXT_XML in supportedReturnMimeTypes ||
 			MimeType.TEXT_HTML in supportedReturnMimeTypes ||
 			MimeType.APPLICATION_X_JAVASCRIPT in supportedReturnMimeTypes ->
-				String::class.asTypeName()
+				TYPE_STRING
 			// Binary types
 			MimeType.AUDIO_ALL in supportedReturnMimeTypes ||
 			MimeType.VIDEO_ALL in supportedReturnMimeTypes ||
 			MimeType.IMAGE_ALL in supportedReturnMimeTypes ||
 			MimeType.APPLICATION_X_MPEG_URL in supportedReturnMimeTypes ||
 			MimeType.APPLICATION_OCTET_STREAM in supportedReturnMimeTypes ->
-				InputStream::class.asTypeName()
+				TYPE_BINARY
 			// JSON (restful) types
 			MimeType.APPLICATION_JSON in supportedReturnMimeTypes -> {
 				val schema = response!!.content[MimeType.APPLICATION_JSON]!!.schema
 				openApiTypeBuilder.build(path, schema)
 			}
 			// Default to no response
-			else -> Unit::class.asTypeName()
+			else -> TYPE_NONE
 		}
+	}
+
+	companion object {
+		val TYPE_STRING = String::class.asTypeName()
+		val TYPE_BINARY = InputStream::class.asTypeName()
+		val TYPE_NONE = Unit::class.asTypeName()
 	}
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/HooksModule.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/HooksModule.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.openapi.hooks
 
+import org.jellyfin.openapi.hooks.api.BinaryOperationUrlHook
 import org.jellyfin.openapi.hooks.model.ImageMapsHook
 import org.jellyfin.openapi.hooks.model.NullableReferencesHook
 import org.koin.dsl.bind
@@ -8,4 +9,5 @@ import org.koin.dsl.module
 val hooksModule = module {
 	single { ImageMapsHook() } bind TypeBuilderHook::class
 	single { NullableReferencesHook() } bind TypeBuilderHook::class
+	single { BinaryOperationUrlHook() } bind OperationUrlHook::class
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/OperationUrlHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/OperationUrlHook.kt
@@ -1,0 +1,11 @@
+package org.jellyfin.openapi.hooks
+
+import org.jellyfin.openapi.model.ApiService
+import org.jellyfin.openapi.model.ApiServiceOperation
+
+interface OperationUrlHook {
+	/**
+	 * Determine if a function should be added to get the URL of a given operation
+	 */
+	fun shouldOperationBuildUrlFun(api: ApiService, operation: ApiServiceOperation): Boolean
+}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/api/BinaryOperationUrlHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/api/BinaryOperationUrlHook.kt
@@ -1,0 +1,12 @@
+package org.jellyfin.openapi.hooks.api
+
+import org.jellyfin.openapi.builder.openapi.OpenApiReturnTypeBuilder.Companion.TYPE_BINARY
+import org.jellyfin.openapi.hooks.OperationUrlHook
+import org.jellyfin.openapi.model.ApiService
+import org.jellyfin.openapi.model.ApiServiceOperation
+import org.jellyfin.openapi.model.HttpMethod
+
+class BinaryOperationUrlHook : OperationUrlHook {
+	override fun shouldOperationBuildUrlFun(api: ApiService, operation: ApiServiceOperation) =
+		operation.method == HttpMethod.GET && operation.returnType == TYPE_BINARY
+}


### PR DESCRIPTION
Because we need things like `ImageApi.getItemImageUrl` for Glide etc.

It uses a hook so we can easily change the behavior. The current behavior is to always create url functions for operations that use a GET request and return binary data.

_Like always, I suggest reviewing per commit._