### PR TITLE
Add discovery models to ProGuard rules

### DIFF
--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,1 +1,2 @@
 -keep class org.jellyfin.apiclient.model.**.* { *; }
+-keep class org.jellyfin.apiclient.discovery.* { *; }


### PR DESCRIPTION
**This PR targets the release branch**

Added an additional rule to the ProGuard configuration to fix jellyfin/jellyfin-android#147.

I'll tag a release after merge