### PR TITLE
Enable Android core library desugaring

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
 	}
 
 	dependencies {
-		classpath(Dependencies.androidBuildTools)
+		classpath(Dependencies.Android.buildTools)
 		classpath(Dependencies.Kotlin.gradlePlugin)
 	}
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -21,7 +21,7 @@ object Dependencies {
 
 		val cli = item("cli", "0.2.1")
 		val coroutinesCore = item("coroutines-core", "1.3.9")
-		val serializationCore = item("serialization-core", "1.0.0-RC")
+		val serializationJson = item("serialization-json", "1.0.0")
 	}
 
 	object Android {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,21 +2,6 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.kotlin.dsl.project
 
 object Dependencies {
-	object KotlinX {
-		private fun item(module: String, version: String) = "org.jetbrains.kotlinx:kotlinx-${module}:${version}"
-
-		val cli = item("cli", "0.2.1")
-		val coroutinesCore = item("coroutines-core", "1.3.9")
-		val serializationCore = item("serialization-core", "1.0.0-RC")
-	}
-
-	object AndroidX {
-		private fun item(library: String, module: String = library, version: String) = "androidx.${library}:${module}:${version}"
-
-		val core = item("core", "core-ktx", "1.3.0")
-		val annotation = item("annotation", version = "1.1.0")
-	}
-
 	object Kotlin {
 		const val version = "1.4.10"
 		private fun item(library: String) = "org.jetbrains.kotlin:kotlin-$library:$version"
@@ -29,6 +14,26 @@ object Dependencies {
 
 			val junit = testItem("junit")
 		}
+	}
+
+	object KotlinX {
+		private fun item(module: String, version: String) = "org.jetbrains.kotlinx:kotlinx-${module}:${version}"
+
+		val cli = item("cli", "0.2.1")
+		val coroutinesCore = item("coroutines-core", "1.3.9")
+		val serializationCore = item("serialization-core", "1.0.0-RC")
+	}
+
+	object Android {
+		const val buildTools = "com.android.tools.build:gradle:4.0.1"
+		const val desugarJdkLibs = "com.android.tools:desugar_jdk_libs:1.0.10"
+	}
+
+	object AndroidX {
+		private fun item(library: String, module: String = library, version: String) = "androidx.${library}:${module}:${version}"
+
+		val core = item("core", "core-ktx", "1.3.0")
+		val annotation = item("annotation", version = "1.1.0")
 	}
 
 	object Ktor {
@@ -57,7 +62,6 @@ object Dependencies {
 	}
 
 	// Non-categorised dependencies
-	const val androidBuildTools = "com.android.tools.build:gradle:4.0.1"
 	const val swaggerParser = "io.swagger.parser.v3:swagger-parser:2.0.19"
 	const val kotlinPoet = "com.squareup:kotlinpoet:1.6.0"
 	const val kasechange = "net.pearx.kasechange:kasechange:1.3.0"

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -3,8 +3,6 @@ plugins {
 }
 
 dependencies {
-	implementation(Dependencies.Kotlin.stdlib)
-
 	implementationProject(":jellyfin-model")
 
 	// HTTP

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -6,9 +6,8 @@ dependencies {
 	apiProject(":jellyfin-api")
 	apiProject(":jellyfin-model")
 
-	implementation(Dependencies.Kotlin.stdlib)
 	implementation(Dependencies.KotlinX.coroutinesCore)
-	implementation(Dependencies.KotlinX.serializationCore)
+	implementation(Dependencies.KotlinX.serializationJson)
 
 	implementation(Dependencies.Ktor.http)
 

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -4,12 +4,11 @@ plugins {
 }
 
 dependencies {
-	implementation(Dependencies.Kotlin.stdlib)
-	compileOnly(Dependencies.KotlinX.serializationCore)
+	compileOnly(Dependencies.KotlinX.serializationJson)
 
 	// Testing
 	testImplementation(Dependencies.Kotlin.Test.junit)
-	testImplementation(Dependencies.KotlinX.serializationCore)
+	testImplementation(Dependencies.KotlinX.serializationJson)
 }
 
 sourceSets.getByName("main").java.srcDir("src/main/kotlin-generated")

--- a/jellyfin-platform-android/build.gradle.kts
+++ b/jellyfin-platform-android/build.gradle.kts
@@ -6,11 +6,12 @@ plugins {
 }
 
 android {
-	compileSdkVersion(29)
+	compileSdkVersion(30)
 
 	defaultConfig {
 		minSdkVersion(19)
-		targetSdkVersion(29)
+		targetSdkVersion(30)
+		multiDexEnabled = true
 
 		versionCode = getVersionCode(project.version.toString()) ?: 0
 		versionName = project.version.toString()
@@ -19,6 +20,8 @@ android {
 	}
 
 	compileOptions {
+		coreLibraryDesugaringEnabled = true
+
 		sourceCompatibility = JavaVersion.VERSION_1_8
 		targetCompatibility = JavaVersion.VERSION_1_8
 	}
@@ -64,4 +67,6 @@ dependencies {
 
 	implementation(Dependencies.AndroidX.core)
 	implementation(Dependencies.AndroidX.annotation)
+
+	coreLibraryDesugaring(Dependencies.Android.desugarJdkLibs)
 }

--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -8,8 +8,6 @@ application {
 }
 
 dependencies {
-	implementation(Dependencies.Kotlin.stdlib)
-
 	// Reading OpenAPI
 	implementation(Dependencies.swaggerParser)
 
@@ -20,7 +18,7 @@ dependencies {
 	implementation(Dependencies.kotlinPoet)
 
 	// Needed for the kotlinx.serialization annotations
-	implementation(Dependencies.KotlinX.serializationCore)
+	implementation(Dependencies.KotlinX.serializationJson)
 
 	// Dependency Injection
 	implementation(Dependencies.Koin.core)


### PR DESCRIPTION
Changes:
- Enabled Android core library desugaring
  - [Documentation](https://developer.android.com/studio/write/java8-support]
  - This is required to use java.time in older Android versions
  - Untested at this moment, need to test one of the apps (ATV/android) in an emulator when upgraded
- Upgraded to kotlinx.serialization 1.0.0
  - Since the JSON functionality is now it's own library I had to change the dependencies to use the json library
- Removed stdlib dependency since Kotlin 1.4 adds it automagically
