### PR TITLE
chore(repo): add basic GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a bug report
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+
+<!-- Steps to reproduce the behavior: -->
+ 1. Do this '...'
+ 2. Use that '...'
+ 3. See error
+
+**Expected behavior**
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Logs**
+
+<!-- Please paste any log errors. -->
+
+**System (please complete the following information):**
+
+  - API version: [e.g. v0.7.6]
+  - Jellyfin server version: [e.g. 10.6.4]
+
+**Additional context**
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Jellyfin documentation
+    url:  https://jellyfin.org/docs/getting-help.html
+    about: Our documentation contains lots of help for common issues

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature Request
+about: Request a new feature
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Describe the feature you'd like**
+
+<!-- A clear and concise description of what you want to happen. -->
+
+**Additional context**
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**Description**
+
+<!-- A brief description of this PR -->
+
+**Changes**
+
+<!-- A list of changes within this PR -->
+
+**Issues**
+
+<!-- A list of relevant issues to this PR -->


### PR DESCRIPTION
Since I noticed that this repository has no GitHub templates for Issues or PRs I decided to open this.
I took inspiration from the jellyfin/jellyfin-andorid repository for the Issue templates (yet not 100% sure how applicable they are for the API client :thinking: ) and added a basic PR template.

**Changes**

* add basic GitHub PR template
* add basic GitHub Issue templates (based on example: jellyfin/jellyfin-andorid)

**Issues**

* N/A

**NOTE**

If you don't want to do this in every repository or simply want to overwrite/customize it for some of them have a look at [Creating a default community health file](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-default-community-health-file).
I mentioned this a while back in Matrix, with some of the team (including joshuaboniface) expressing interest and mentioning that this was not released during the creation of the organization, but seems to never got any track.
Just a FYI :wink: 