### PR TITLE
update(ci): change ci publish steps ... again

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -61,10 +61,11 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
 
-    steps:
-      - script: echo "##vso[task.setvariable variable=JELLYFIN_VERSION]$( awk -F '/' '{ print $NF }' <<<'$(Build.SourceBranch)' | sed 's/^v//' )"
-        displayName: 'Set Version Variable'
+    variables:
+      - name: JELLYFIN_VERSION
+        value: $[replace(variables['Build.SourceBranch'],'refs/tags/v','')]
 
+    steps:
       - task: Gradle@2
         displayName: 'Build, Distribute & Publish'
         inputs:

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -85,6 +85,7 @@ jobs:
             **/distributions/*-$(JELLYFIN_VERSION).zip
             **/libs/*-$(JELLYFIN_VERSION).jar
             **/libs/*-$(JELLYFIN_VERSION)-sources.jar
+            **/outputs/aar/*.aar
           TargetFolder: '$(Build.ArtifactStagingDirectory)'
           flattenFolders: true
 

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
       vmImage: 'ubuntu-latest'
 
     steps:
-      - script: 'echo "##vso[task.setvariable variable=JELLYFIN_VERSION]$(git describe --tags)"'
+      - script: echo "##vso[task.setvariable variable=JELLYFIN_VERSION]$( awk -F '/' '{ print $NF }' <<<'$(Build.SourceBranch)' | sed 's/^v//' )"
         displayName: 'Set Version Variable'
 
       - task: Gradle@2
@@ -89,4 +89,4 @@ jobs:
             $(Build.ArtifactStagingDirectory)/**/libs/*-$(JELLYFIN_VERSION)-sources.jar
           action: 'edit'
           assetUploadMode: 'replace'
-          tag: '$(JELLYFIN_VERSION)'
+          tag: 'v$(JELLYFIN_VERSION)'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -78,15 +78,21 @@ jobs:
         env:
           BINTRAY_KEY: $(bintray_key)
 
+      - task: CopyFiles@2
+        displayName: 'Copy build assets'
+        inputs:
+          Contents: |
+            **/distributions/*-$(JELLYFIN_VERSION).zip
+            **/libs/*-$(JELLYFIN_VERSION).jar
+            **/libs/*-$(JELLYFIN_VERSION)-sources.jar
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'
+          flattenFolders: true
+
       - task: GitHubRelease@1
         displayName: 'GitHub Upload'
         inputs:
           gitHubConnection: Jellyfin Release Download
           repositoryName: jellyfin/jellyfin-apiclient-java
-          assets: |
-            $(Build.ArtifactStagingDirectory)/**/distributions/*-$(JELLYFIN_VERSION).zip
-            $(Build.ArtifactStagingDirectory)/**/libs/*-$(JELLYFIN_VERSION).jar
-            $(Build.ArtifactStagingDirectory)/**/libs/*-$(JELLYFIN_VERSION)-sources.jar
           action: 'edit'
           assetUploadMode: 'replace'
           tag: 'v$(JELLYFIN_VERSION)'


### PR DESCRIPTION
**Changes**

* updates how the `JELLYFIN_VERSION` gets set (uses now the same mechanism as [jellyfin/jellyfin](https://github.com/jellyfin/jellyfin/blob/2375c35c4a966a469dd97f33deb57b342498b905/.ci/azure-pipelines-package.yml#L119))
* updates GitHubRelease task to select correct tag with new `JELLYFIN_VERSION`
* change to align publish steps more with the ci in jenkins/jenkins-androidtv ([Line 75 and down](https://github.com/jellyfin/jellyfin-androidtv/blob/727a2e8e351ac9a1e18049c7dd303005ecabbff7/.ci/azure-pipelines.yml#L75))

**Issues**

* more #83 

**Relevant Documentation**

* [GitHubRelease task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release)
  * > Assets - (Optional) Specify  the files to be uploaded as assets for the release. You can use wildcard  characters to specify a set of files. E.g. $(Build.ArtifactStagingDirectory)/*.zip. You can also specify multiple patterns - one per line. By default, all files in the $(Build.ArtifactStagingDirectory) directory will be uploaded.

* [CopyFiles](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/copy-files)
  * > Contents - (Required) File paths to include as part of the copy. Supports multiple lines of match patterns. More Information. For example: * copies all files in the specified source folder** copies all files in the specified source folder and all files in all sub-folders**\bin\** copies all files recursively from any bin folder The  pattern is used to match only file paths, not folder paths. So you  should specify patterns such as **\bin\** instead of **\bin.You must use the path separator that matches your build agent type. Example, / must be used for Linux agents. More examples are shown below. Default value: **

* [Build Variables (DevOps Services)](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services)
  * > Build.ArtifactStagingDirectory - The local path on the agent where any artifacts are copied to before being pushed to their destination. For example: c:\agent_work\1\a  A typical way to use this folder is to publish your build artifacts with the Copy files and Publish build artifacts tasks.  Note: Build.ArtifactStagingDirectory and Build.StagingDirectory are  interchangeable. **This directory is purged before each new build, so you  don't have to clean it up yourself.**  See Artifacts in Azure Pipelines.  This variable is agent-scoped, and can be used as an environment  variable in a script and as a parameter in a build task, but not as part  of the build number or as a version control tag.