### PR TITLE
Add default values to API operations

### DIFF
--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ArtistsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ArtistsApi.kt
@@ -85,7 +85,7 @@ class ArtistsApi(
 		fields: String? = null,
 		excludeItemTypes: String? = null,
 		includeItemTypes: String? = null,
-		filters: List<ItemFilter>? = null,
+		filters: List<ItemFilter>? = emptyList(),
 		isFavorite: Boolean? = null,
 		mediaTypes: String? = null,
 		genres: String? = null,
@@ -105,8 +105,8 @@ class ArtistsApi(
 		nameStartsWithOrGreater: String? = null,
 		nameStartsWith: String? = null,
 		nameLessThan: String? = null,
-		enableImages: Boolean? = null,
-		enableTotalRecordCount: Boolean
+		enableImages: Boolean? = true,
+		enableTotalRecordCount: Boolean = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
@@ -225,7 +225,7 @@ class ArtistsApi(
 		fields: String? = null,
 		excludeItemTypes: String? = null,
 		includeItemTypes: String? = null,
-		filters: List<ItemFilter>? = null,
+		filters: List<ItemFilter>? = emptyList(),
 		isFavorite: Boolean? = null,
 		mediaTypes: String? = null,
 		genres: String? = null,
@@ -245,8 +245,8 @@ class ArtistsApi(
 		nameStartsWithOrGreater: String? = null,
 		nameStartsWith: String? = null,
 		nameLessThan: String? = null,
-		enableImages: Boolean? = null,
-		enableTotalRecordCount: Boolean
+		enableImages: Boolean? = true,
+		enableTotalRecordCount: Boolean = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/AudioApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/AudioApi.kt
@@ -139,7 +139,7 @@ class AudioApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = emptyMap()
 	): Response<ByteReadChannel> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -488,7 +488,7 @@ class AudioApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = emptyMap()
 	): Response<ByteReadChannel> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ChannelsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ChannelsApi.kt
@@ -93,7 +93,7 @@ class ChannelsApi(
 		startIndex: Int? = null,
 		limit: Int? = null,
 		sortOrder: String? = null,
-		filters: List<ItemFilter>? = null,
+		filters: List<ItemFilter>? = emptyList(),
 		sortBy: String? = null,
 		fields: String? = null
 	): Response<BaseItemDtoQueryResult> {
@@ -144,7 +144,7 @@ class ChannelsApi(
 		userId: UUID? = null,
 		startIndex: Int? = null,
 		limit: Int? = null,
-		filters: List<ItemFilter>? = null,
+		filters: List<ItemFilter>? = emptyList(),
 		fields: String? = null,
 		channelIds: String? = null
 	): Response<BaseItemDtoQueryResult> {

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/CollectionApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/CollectionApi.kt
@@ -29,7 +29,7 @@ class CollectionApi(
 		name: String? = null,
 		ids: String? = null,
 		parentId: UUID? = null,
-		isLocked: Boolean
+		isLocked: Boolean = false
 	): Response<CollectionCreationResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/DynamicHlsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/DynamicHlsApi.kt
@@ -144,7 +144,7 @@ class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = emptyMap()
 	): Response<ByteReadChannel> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -502,7 +502,7 @@ class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = emptyMap()
 	): Response<ByteReadChannel> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -846,8 +846,8 @@ class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null,
-		enableAdaptiveBitrateStreaming: Boolean
+		streamOptions: Map<String, String>? = emptyMap(),
+		enableAdaptiveBitrateStreaming: Boolean = true
 	): Response<ByteReadChannel> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -1201,7 +1201,7 @@ class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = emptyMap()
 	): Response<ByteReadChannel> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -1559,7 +1559,7 @@ class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = emptyMap()
 	): Response<ByteReadChannel> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -1903,8 +1903,8 @@ class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null,
-		enableAdaptiveBitrateStreaming: Boolean
+		streamOptions: Map<String, String>? = emptyMap(),
+		enableAdaptiveBitrateStreaming: Boolean = true
 	): Response<ByteReadChannel> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/EnvironmentApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/EnvironmentApi.kt
@@ -42,8 +42,8 @@ class EnvironmentApi(
 	 */
 	suspend fun getDirectoryContents(
 		path: String,
-		includeFiles: Boolean,
-		includeDirectories: Boolean
+		includeFiles: Boolean = false,
+		includeDirectories: Boolean = false
 	): Response<List<FileSystemEntryInfo>> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/GenresApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/GenresApi.kt
@@ -85,7 +85,7 @@ class GenresApi(
 		fields: String? = null,
 		excludeItemTypes: String? = null,
 		includeItemTypes: String? = null,
-		filters: List<ItemFilter>? = null,
+		filters: List<ItemFilter>? = emptyList(),
 		isFavorite: Boolean? = null,
 		mediaTypes: String? = null,
 		genres: String? = null,
@@ -105,8 +105,8 @@ class GenresApi(
 		nameStartsWithOrGreater: String? = null,
 		nameStartsWith: String? = null,
 		nameLessThan: String? = null,
-		enableImages: Boolean? = null,
-		enableTotalRecordCount: Boolean
+		enableImages: Boolean? = true,
+		enableTotalRecordCount: Boolean = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ItemLookupApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ItemLookupApi.kt
@@ -52,7 +52,7 @@ class ItemLookupApi(
 	 */
 	suspend fun applySearchCriteria(
 		itemId: UUID,
-		replaceAllImages: Boolean,
+		replaceAllImages: Boolean = true,
 		data: RemoteSearchResult
 	): Response<Unit> {
 		val pathParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ItemRefreshApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ItemRefreshApi.kt
@@ -32,8 +32,8 @@ class ItemRefreshApi(
 		itemId: UUID,
 		metadataRefreshMode: MetadataRefreshMode,
 		imageRefreshMode: MetadataRefreshMode,
-		replaceAllMetadata: Boolean,
-		replaceAllImages: Boolean
+		replaceAllMetadata: Boolean = false,
+		replaceAllImages: Boolean = false
 	): Response<Unit> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ItemsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ItemsApi.kt
@@ -162,7 +162,7 @@ class ItemsApi(
 		isHd: Boolean? = null,
 		is4k: Boolean? = null,
 		locationTypes: String? = null,
-		excludeLocationTypes: List<LocationType>? = null,
+		excludeLocationTypes: List<LocationType>? = emptyList(),
 		isMissing: Boolean? = null,
 		isUnaired: Boolean? = null,
 		minCommunityRating: Double? = null,
@@ -185,7 +185,7 @@ class ItemsApi(
 		fields: String? = null,
 		excludeItemTypes: String? = null,
 		includeItemTypes: String? = null,
-		filters: List<ItemFilter>? = null,
+		filters: List<ItemFilter>? = emptyList(),
 		isFavorite: Boolean? = null,
 		mediaTypes: String? = null,
 		imageTypes: String? = null,
@@ -227,8 +227,8 @@ class ItemsApi(
 		nameLessThan: String? = null,
 		studioIds: String? = null,
 		genreIds: String? = null,
-		enableTotalRecordCount: Boolean,
-		enableImages: Boolean? = null
+		enableTotalRecordCount: Boolean = true,
+		enableImages: Boolean? = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["uId"] = uId
@@ -458,7 +458,7 @@ class ItemsApi(
 		isHd: Boolean? = null,
 		is4k: Boolean? = null,
 		locationTypes: String? = null,
-		excludeLocationTypes: List<LocationType>? = null,
+		excludeLocationTypes: List<LocationType>? = emptyList(),
 		isMissing: Boolean? = null,
 		isUnaired: Boolean? = null,
 		minCommunityRating: Double? = null,
@@ -481,7 +481,7 @@ class ItemsApi(
 		fields: String? = null,
 		excludeItemTypes: String? = null,
 		includeItemTypes: String? = null,
-		filters: List<ItemFilter>? = null,
+		filters: List<ItemFilter>? = emptyList(),
 		isFavorite: Boolean? = null,
 		mediaTypes: String? = null,
 		imageTypes: String? = null,
@@ -523,8 +523,8 @@ class ItemsApi(
 		nameLessThan: String? = null,
 		studioIds: String? = null,
 		genreIds: String? = null,
-		enableTotalRecordCount: Boolean,
-		enableImages: Boolean? = null
+		enableTotalRecordCount: Boolean = true,
+		enableImages: Boolean? = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["uId"] = uId
@@ -652,8 +652,8 @@ class ItemsApi(
 		enableImageTypes: String? = null,
 		excludeItemTypes: String? = null,
 		includeItemTypes: String? = null,
-		enableTotalRecordCount: Boolean,
-		enableImages: Boolean? = null
+		enableTotalRecordCount: Boolean = true,
+		enableImages: Boolean? = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["userId"] = userId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LibraryApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LibraryApi.kt
@@ -247,7 +247,7 @@ class LibraryApi(
 	suspend fun getThemeMedia(
 		itemId: UUID,
 		userId: UUID? = null,
-		inheritFromParent: Boolean
+		inheritFromParent: Boolean = false
 	): Response<AllThemeMediaResult> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -271,7 +271,7 @@ class LibraryApi(
 	suspend fun getThemeSongs(
 		itemId: UUID,
 		userId: UUID? = null,
-		inheritFromParent: Boolean
+		inheritFromParent: Boolean = false
 	): Response<ThemeMediaResult> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -295,7 +295,7 @@ class LibraryApi(
 	suspend fun getThemeVideos(
 		itemId: UUID,
 		userId: UUID? = null,
-		inheritFromParent: Boolean
+		inheritFromParent: Boolean = false
 	): Response<ThemeMediaResult> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LibraryStructureApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LibraryStructureApi.kt
@@ -44,8 +44,8 @@ class LibraryStructureApi(
 	suspend fun addVirtualFolder(
 		name: String? = null,
 		collectionType: String? = null,
-		paths: List<String>? = null,
-		refreshLibrary: Boolean,
+		paths: List<String>? = emptyList(),
+		refreshLibrary: Boolean = false,
 		data: AddVirtualFolderDto
 	): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
@@ -64,7 +64,8 @@ class LibraryStructureApi(
 	 * @param name The name of the folder.
 	 * @param refreshLibrary Whether to refresh the library.
 	 */
-	suspend fun removeVirtualFolder(name: String? = null, refreshLibrary: Boolean): Response<Unit> {
+	suspend fun removeVirtualFolder(name: String? = null, refreshLibrary: Boolean = false):
+			Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
 		queryParameters["name"] = name
@@ -95,7 +96,7 @@ class LibraryStructureApi(
 	suspend fun renameVirtualFolder(
 		name: String? = null,
 		newName: String? = null,
-		refreshLibrary: Boolean
+		refreshLibrary: Boolean = false
 	): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
@@ -113,7 +114,7 @@ class LibraryStructureApi(
 	 *
 	 * @param refreshLibrary Whether to refresh the library.
 	 */
-	suspend fun addMediaPath(refreshLibrary: Boolean, data: MediaPathDto): Response<Unit> {
+	suspend fun addMediaPath(refreshLibrary: Boolean = false, data: MediaPathDto): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
 		queryParameters["refreshLibrary"] = refreshLibrary
@@ -132,7 +133,7 @@ class LibraryStructureApi(
 	suspend fun removeMediaPath(
 		name: String? = null,
 		path: String? = null,
-		refreshLibrary: Boolean
+		refreshLibrary: Boolean = false
 	): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LiveTvApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LiveTvApi.kt
@@ -127,8 +127,8 @@ class LiveTvApi(
 		enableUserData: Boolean? = null,
 		sortBy: String? = null,
 		sortOrder: SortOrder,
-		enableFavoriteSorting: Boolean,
-		addCurrentProgram: Boolean
+		enableFavoriteSorting: Boolean = false,
+		addCurrentProgram: Boolean = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
@@ -207,8 +207,8 @@ class LiveTvApi(
 	 */
 	suspend fun addListingProvider(
 		pw: String? = null,
-		validateListings: Boolean,
-		validateLogin: Boolean,
+		validateListings: Boolean = false,
+		validateLogin: Boolean = false,
 		data: ListingsProviderInfo
 	): Response<ListingsProviderInfo> {
 		val pathParameters = emptyMap<String, Any?>()
@@ -418,7 +418,7 @@ class LiveTvApi(
 		seriesTimerId: String? = null,
 		librarySeriesId: UUID? = null,
 		fields: String? = null,
-		enableTotalRecordCount: Boolean
+		enableTotalRecordCount: Boolean = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
@@ -522,7 +522,7 @@ class LiveTvApi(
 		genreIds: String? = null,
 		fields: String? = null,
 		enableUserData: Boolean? = null,
-		enableTotalRecordCount: Boolean
+		enableTotalRecordCount: Boolean = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
@@ -594,7 +594,7 @@ class LiveTvApi(
 		isSports: Boolean? = null,
 		isNews: Boolean? = null,
 		isLibraryItem: Boolean? = null,
-		enableTotalRecordCount: Boolean
+		enableTotalRecordCount: Boolean = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
@@ -739,7 +739,7 @@ class LiveTvApi(
 		enableImageTypes: String? = null,
 		fields: String? = null,
 		enableUserData: Boolean? = null,
-		enableTotalRecordCount: Boolean
+		enableTotalRecordCount: Boolean = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
@@ -985,7 +985,7 @@ class LiveTvApi(
 	 *
 	 * @param newDevicesOnly Only discover new tuners.
 	 */
-	suspend fun discoverTuners(newDevicesOnly: Boolean): Response<List<TunerHostInfo>> {
+	suspend fun discoverTuners(newDevicesOnly: Boolean = false): Response<List<TunerHostInfo>> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
 		queryParameters["newDevicesOnly"] = newDevicesOnly

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MediaInfoApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MediaInfoApi.kt
@@ -69,12 +69,12 @@ class MediaInfoApi(
 		maxAudioChannels: Int? = null,
 		mediaSourceId: String? = null,
 		liveStreamId: String? = null,
-		autoOpenLiveStream: Boolean,
-		enableDirectPlay: Boolean,
-		enableDirectStream: Boolean,
-		enableTranscoding: Boolean,
-		allowVideoStreamCopy: Boolean,
-		allowAudioStreamCopy: Boolean,
+		autoOpenLiveStream: Boolean = false,
+		enableDirectPlay: Boolean = true,
+		enableDirectStream: Boolean = true,
+		enableTranscoding: Boolean = true,
+		allowVideoStreamCopy: Boolean = true,
+		allowAudioStreamCopy: Boolean = true,
 		data: DeviceProfileDto
 	): Response<PlaybackInfoResponse> {
 		val pathParameters = mutableMapOf<String, Any?>()
@@ -138,8 +138,8 @@ class MediaInfoApi(
 		subtitleStreamIndex: Int? = null,
 		maxAudioChannels: Int? = null,
 		itemId: UUID? = null,
-		enableDirectPlay: Boolean,
-		enableDirectStream: Boolean,
+		enableDirectPlay: Boolean = true,
+		enableDirectStream: Boolean = true,
 		data: OpenLiveStreamDto
 	): Response<LiveStreamResponse> {
 		val pathParameters = emptyMap<String, Any?>()
@@ -165,7 +165,7 @@ class MediaInfoApi(
 	 *
 	 * @param size The bitrate. Defaults to 102400.
 	 */
-	suspend fun getBitrateTestBytes(size: Int): Response<ByteReadChannel> {
+	suspend fun getBitrateTestBytes(size: Int = 102400): Response<ByteReadChannel> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
 		queryParameters["size"] = size

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MoviesApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MoviesApi.kt
@@ -31,8 +31,8 @@ class MoviesApi(
 		userId: UUID? = null,
 		parentId: String? = null,
 		fields: String? = null,
-		categoryLimit: Int,
-		itemLimit: Int
+		categoryLimit: Int = 5,
+		itemLimit: Int = 8
 	): Response<List<RecommendationDto>> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MusicGenresApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MusicGenresApi.kt
@@ -85,7 +85,7 @@ class MusicGenresApi(
 		fields: String? = null,
 		excludeItemTypes: String? = null,
 		includeItemTypes: String? = null,
-		filters: List<ItemFilter>? = null,
+		filters: List<ItemFilter>? = emptyList(),
 		isFavorite: Boolean? = null,
 		mediaTypes: String? = null,
 		genres: String? = null,
@@ -105,8 +105,8 @@ class MusicGenresApi(
 		nameStartsWithOrGreater: String? = null,
 		nameStartsWith: String? = null,
 		nameLessThan: String? = null,
-		enableImages: Boolean? = null,
-		enableTotalRecordCount: Boolean
+		enableImages: Boolean? = true,
+		enableTotalRecordCount: Boolean = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/NotificationsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/NotificationsApi.kt
@@ -83,8 +83,8 @@ class NotificationsApi(
 	suspend fun createAdminNotification(
 		url: String? = null,
 		level: NotificationLevel,
-		name: String? = null,
-		description: String? = null
+		name: String? = "",
+		description: String? = ""
 	): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/PersonsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/PersonsApi.kt
@@ -87,7 +87,7 @@ class PersonsApi(
 		fields: String? = null,
 		excludeItemTypes: String? = null,
 		includeItemTypes: String? = null,
-		filters: List<ItemFilter>? = null,
+		filters: List<ItemFilter>? = emptyList(),
 		isFavorite: Boolean? = null,
 		mediaTypes: String? = null,
 		genres: String? = null,
@@ -107,8 +107,8 @@ class PersonsApi(
 		nameStartsWithOrGreater: String? = null,
 		nameStartsWith: String? = null,
 		nameLessThan: String? = null,
-		enableImages: Boolean? = null,
-		enableTotalRecordCount: Boolean
+		enableImages: Boolean? = true,
+		enableTotalRecordCount: Boolean = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/PlaystateApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/PlaystateApi.kt
@@ -131,7 +131,7 @@ class PlaystateApi(
 		playMethod: PlayMethod,
 		liveStreamId: String? = null,
 		playSessionId: String? = null,
-		canSeek: Boolean
+		canSeek: Boolean = false
 	): Response<Unit> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["userId"] = userId
@@ -215,8 +215,8 @@ class PlaystateApi(
 		liveStreamId: String? = null,
 		playSessionId: String? = null,
 		repeatMode: RepeatMode,
-		isPaused: Boolean,
-		isMuted: Boolean
+		isPaused: Boolean = false,
+		isMuted: Boolean = false
 	): Response<Unit> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["userId"] = userId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/RemoteImageApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/RemoteImageApi.kt
@@ -65,7 +65,7 @@ class RemoteImageApi(
 		startIndex: Int? = null,
 		limit: Int? = null,
 		providerName: String? = null,
-		includeAllLanguages: Boolean
+		includeAllLanguages: Boolean = false
 	): Response<RemoteImageResult> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/SearchApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/SearchApi.kt
@@ -58,11 +58,11 @@ class SearchApi(
 		isNews: Boolean? = null,
 		isKids: Boolean? = null,
 		isSports: Boolean? = null,
-		includePeople: Boolean,
-		includeMedia: Boolean,
-		includeGenres: Boolean,
-		includeStudios: Boolean,
-		includeArtists: Boolean
+		includePeople: Boolean = true,
+		includeMedia: Boolean = true,
+		includeGenres: Boolean = true,
+		includeStudios: Boolean = true,
+		includeArtists: Boolean = true
 	): Response<SearchHintResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/SessionApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/SessionApi.kt
@@ -273,10 +273,10 @@ class SessionApi(
 	suspend fun postCapabilities(
 		id: String? = null,
 		playableMediaTypes: String? = null,
-		supportedCommands: List<GeneralCommandType>? = null,
-		supportsMediaControl: Boolean,
-		supportsSync: Boolean,
-		supportsPersistentIdentifier: Boolean
+		supportedCommands: List<GeneralCommandType>? = emptyList(),
+		supportsMediaControl: Boolean = false,
+		supportsSync: Boolean = false,
+		supportsPersistentIdentifier: Boolean = true
 	): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/StudiosApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/StudiosApi.kt
@@ -85,7 +85,7 @@ class StudiosApi(
 		fields: String? = null,
 		excludeItemTypes: String? = null,
 		includeItemTypes: String? = null,
-		filters: List<ItemFilter>? = null,
+		filters: List<ItemFilter>? = emptyList(),
 		isFavorite: Boolean? = null,
 		mediaTypes: String? = null,
 		genres: String? = null,
@@ -105,8 +105,8 @@ class StudiosApi(
 		nameStartsWithOrGreater: String? = null,
 		nameStartsWith: String? = null,
 		nameLessThan: String? = null,
-		enableImages: Boolean? = null,
-		enableTotalRecordCount: Boolean
+		enableImages: Boolean? = true,
+		enableTotalRecordCount: Boolean = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/SubtitleApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/SubtitleApi.kt
@@ -94,10 +94,10 @@ class SubtitleApi(
 		mediaSourceId: String,
 		index: Int,
 		format: String,
-		startPositionTicks: Long,
+		startPositionTicks: Long = 0,
 		endPositionTicks: Long? = null,
-		copyTimestamps: Boolean,
-		addVttTimeMap: Boolean
+		copyTimestamps: Boolean = false,
+		addVttTimeMap: Boolean = false
 	): Response<String> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -133,10 +133,10 @@ class SubtitleApi(
 		mediaSourceId: String,
 		index: Int,
 		format: String,
-		startPositionTicks: Long,
+		startPositionTicks: Long = 0,
 		endPositionTicks: Long? = null,
-		copyTimestamps: Boolean,
-		addVttTimeMap: Boolean
+		copyTimestamps: Boolean = false,
+		addVttTimeMap: Boolean = false
 	): Response<String> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/SuggestionsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/SuggestionsApi.kt
@@ -33,7 +33,7 @@ class SuggestionsApi(
 		type: String? = null,
 		startIndex: Int? = null,
 		limit: Int? = null,
-		enableTotalRecordCount: Boolean
+		enableTotalRecordCount: Boolean = false
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["userId"] = userId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/TrailersApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/TrailersApi.kt
@@ -158,7 +158,7 @@ class TrailersApi(
 		isHd: Boolean? = null,
 		is4k: Boolean? = null,
 		locationTypes: String? = null,
-		excludeLocationTypes: List<LocationType>? = null,
+		excludeLocationTypes: List<LocationType>? = emptyList(),
 		isMissing: Boolean? = null,
 		isUnaired: Boolean? = null,
 		minCommunityRating: Double? = null,
@@ -180,7 +180,7 @@ class TrailersApi(
 		parentId: String? = null,
 		fields: String? = null,
 		excludeItemTypes: String? = null,
-		filters: List<ItemFilter>? = null,
+		filters: List<ItemFilter>? = emptyList(),
 		isFavorite: Boolean? = null,
 		mediaTypes: String? = null,
 		imageTypes: String? = null,
@@ -222,8 +222,8 @@ class TrailersApi(
 		nameLessThan: String? = null,
 		studioIds: String? = null,
 		genreIds: String? = null,
-		enableTotalRecordCount: Boolean,
-		enableImages: Boolean? = null
+		enableTotalRecordCount: Boolean = true,
+		enableImages: Boolean? = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/TvShowsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/TvShowsApi.kt
@@ -160,7 +160,7 @@ class TvShowsApi(
 		imageTypeLimit: Int? = null,
 		enableImageTypes: String? = null,
 		enableUserData: Boolean? = null,
-		enableTotalRecordCount: Boolean
+		enableTotalRecordCount: Boolean = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/UniversalAudioApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/UniversalAudioApi.kt
@@ -57,7 +57,7 @@ class UniversalAudioApi(
 		maxAudioBitDepth: Int? = null,
 		enableRemoteMedia: Boolean? = null,
 		breakOnNonKeyFrames: Boolean,
-		enableRedirection: Boolean
+		enableRedirection: Boolean = true
 	): Response<ByteReadChannel> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -186,7 +186,7 @@ class UniversalAudioApi(
 		maxAudioBitDepth: Int? = null,
 		enableRemoteMedia: Boolean? = null,
 		breakOnNonKeyFrames: Boolean,
-		enableRedirection: Boolean
+		enableRedirection: Boolean = true
 	): Response<ByteReadChannel> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/UserLibraryApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/UserLibraryApi.kt
@@ -194,8 +194,8 @@ class UserLibraryApi(
 		imageTypeLimit: Int? = null,
 		enableImageTypes: String? = null,
 		enableUserData: Boolean? = null,
-		limit: Int,
-		groupItems: Boolean
+		limit: Int = 20,
+		groupItems: Boolean = true
 	): Response<List<BaseItemDto>> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["userId"] = userId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/UserViewsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/UserViewsApi.kt
@@ -46,7 +46,7 @@ class UserViewsApi(
 		userId: UUID,
 		includeExternalContent: Boolean? = null,
 		presetViews: String? = null,
-		includeHidden: Boolean
+		includeHidden: Boolean = false
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["userId"] = userId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideoHlsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideoHlsApi.kt
@@ -142,7 +142,7 @@ class VideoHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null,
+		streamOptions: Map<String, String>? = emptyMap(),
 		maxWidth: Int? = null,
 		maxHeight: Int? = null,
 		enableSubtitlesInManifest: Boolean? = null

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideosApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideosApi.kt
@@ -143,7 +143,7 @@ class VideosApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = emptyMap()
 	): Response<ByteReadChannel> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -530,7 +530,7 @@ class VideosApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = emptyMap()
 	): Response<ByteReadChannel> {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/YearsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/YearsApi.kt
@@ -59,8 +59,8 @@ class YearsApi(
 		imageTypeLimit: Int? = null,
 		enableImageTypes: String? = null,
 		userId: UUID? = null,
-		recursive: Boolean,
-		enableImages: Boolean? = null
+		recursive: Boolean = true,
+		enableImages: Boolean? = true
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
@@ -52,6 +52,7 @@ class OpenApiApiServicesBuilder(
 						name = parameterName,
 						originalName = parameterSpec.name,
 						type = type,
+						defaultValue = parameterSpec.schema?.default,
 						description = parameterSpec.description,
 						deprecated = parameterSpec.deprecated == true
 					)

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ApiServiceOperationParameter.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ApiServiceOperationParameter.kt
@@ -6,6 +6,7 @@ data class ApiServiceOperationParameter(
 	val name: String,
 	val originalName: String,
 	val type: TypeName,
+	val defaultValue: Any?,
 	val description: String?,
 	val deprecated: Boolean
 )


### PR DESCRIPTION
Supports strings, integers and booleans set in the OpenAPI spec and adds empty list or empty map for collections.

Collections are still nullable because I can't test the behavior for all these endpoints.

Closes #133  
Closes #132 