### PR TITLE
Normalize the Android device name

### DIFF
--- a/jellyfin-platform-android/build.gradle.kts
+++ b/jellyfin-platform-android/build.gradle.kts
@@ -31,6 +31,7 @@ android {
 	}
 
 	sourceSets["main"].java.srcDirs("src/main/kotlin")
+	sourceSets["test"].java.srcDirs("src/test/kotlin")
 
 	buildTypes {
 		getByName("release") {
@@ -67,6 +68,8 @@ dependencies {
 
 	implementation(Dependencies.AndroidX.core)
 	implementation(Dependencies.AndroidX.annotation)
+
+	testImplementation(Dependencies.Kotlin.Test.junit)
 
 	coreLibraryDesugaring(Dependencies.Android.desugarJdkLibs)
 }

--- a/jellyfin-platform-android/src/main/kotlin/org/jellyfin/apiclient/interaction/AndroidDevice.kt
+++ b/jellyfin-platform-android/src/main/kotlin/org/jellyfin/apiclient/interaction/AndroidDevice.kt
@@ -6,6 +6,18 @@ import android.os.Build
 import android.provider.Settings
 import org.jellyfin.apiclient.model.DeviceInfo
 
+/**
+ * Helper function used in [androidDevice] to normalize device names:
+ *
+ * - Removes special characters from the name.
+ * - Trims the whitespace at the start and end of the name.
+ *
+ * Returns a copy of the device with the normalized name.
+ */
+fun DeviceInfo.normalize() = copy(
+	name = name.replace("[^\\w\\s]".toRegex(), "").trim()
+)
+
 @SuppressLint("HardwareIds")
 fun androidDevice(context: Context): DeviceInfo {
 	val id = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
@@ -18,12 +30,12 @@ fun androidDevice(context: Context): DeviceInfo {
 		val manufacturer = Build.MANUFACTURER
 		val model = Build.MODEL
 
-		if (model.startsWith(manufacturer)) model
+		if (model.startsWith(manufacturer) || manufacturer.isBlank()) model
 		else "$manufacturer $model"
 	}
 
 	return DeviceInfo(
 		id = id,
 		name = name
-	)
+	).normalize()
 }

--- a/jellyfin-platform-android/src/test/kotlin/org/jellyfin/apiclient/interaction/AndroidDeviceTests.kt
+++ b/jellyfin-platform-android/src/test/kotlin/org/jellyfin/apiclient/interaction/AndroidDeviceTests.kt
@@ -1,0 +1,17 @@
+package org.jellyfin.apiclient.interaction
+
+import org.jellyfin.apiclient.model.DeviceInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AndroidDeviceTests {
+	@Test
+	fun `Removes special characters`() {
+		assertEquals("s S9256GB_m", DeviceInfo("","Ã‘Ã¡Å¾Ã Å•'s S9+256GB..._\\m/\"").normalize().name)
+	}
+
+	@Test
+	fun `Keeps normal characters`() {
+		assertEquals("My Awesome Device 123", DeviceInfo("","My Awesome Device 123").normalize().name)
+	}
+}


### PR DESCRIPTION
Fixes some issues we have in the Android app with corrupt device names. See my other PR for a backport. The comment on the [normalize] function explains the changes.