### PR TITLE
Normalize the Android device name (backport)

### DIFF
--- a/android/src/main/kotlin/org/jellyfin/apiclient/interaction/AndroidDevice.kt
+++ b/android/src/main/kotlin/org/jellyfin/apiclient/interaction/AndroidDevice.kt
@@ -11,6 +11,8 @@ data class AndroidDevice(
 	override val deviceName: String
 ) : IDevice {
 	companion object {
+		private fun String.normalize() = replace("[^\\w\\s]".toRegex(), "")
+
 		@SuppressLint("HardwareIds")
 		fun getAutomaticId(context: Context): String =
 			Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
@@ -18,14 +20,14 @@ data class AndroidDevice(
 		fun getAutomaticName(context: Context): String {
 			// Use name from device settings
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-				return Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
+				return Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME).normalize()
 			}
 
 			// Concatenate the name based on manufacturer and model
-			val manufacturer = Build.MANUFACTURER
-			val model = Build.MODEL
+			val manufacturer = Build.MANUFACTURER.normalize()
+			val model = Build.MODEL.normalize()
 
-			return if (model.startsWith(manufacturer)) model
+			return if (model.startsWith(manufacturer) || manufacturer.isBlank()) model
 			else "$manufacturer $model"
 		}
 


### PR DESCRIPTION
# Targets the release-0.7.z branch!!!

Includes a part of the fix in #136 to at least fix the crashes in the Android app for devices with corrupted names. 