### PR TITLE
Improvements in the device name normalization code

### DIFF
--- a/jellyfin-platform-android/src/main/kotlin/org/jellyfin/apiclient/interaction/AndroidDevice.kt
+++ b/jellyfin-platform-android/src/main/kotlin/org/jellyfin/apiclient/interaction/AndroidDevice.kt
@@ -9,13 +9,14 @@ import org.jellyfin.apiclient.model.DeviceInfo
 /**
  * Helper function used in [androidDevice] to normalize device names:
  *
- * - Removes special characters from the name.
+ * - Removes non-US-ASCII-printable characters from the name.
  * - Trims the whitespace at the start and end of the name.
+ * - Removes repetitive whitespace from the name.
  *
  * Returns a copy of the device with the normalized name.
  */
 fun DeviceInfo.normalize() = copy(
-	name = name.replace("[^\\w\\s]".toRegex(), "").trim()
+	name = name.replace("[^\\x20-\\x7E]".toRegex(), "").trim().replace("\\s{2,}".toRegex(), " ")
 )
 
 @SuppressLint("HardwareIds")

--- a/jellyfin-platform-android/src/test/kotlin/org/jellyfin/apiclient/interaction/AndroidDeviceTests.kt
+++ b/jellyfin-platform-android/src/test/kotlin/org/jellyfin/apiclient/interaction/AndroidDeviceTests.kt
@@ -6,12 +6,22 @@ import kotlin.test.assertEquals
 
 class AndroidDeviceTests {
 	@Test
-	fun `Removes special characters`() {
-		assertEquals("s S9256GB_m", DeviceInfo("","Ã‘Ã¡Å¾Ã Å•'s S9+256GB..._\\m/\"").normalize().name)
+	fun `Removes non-US-ASCII-printable characters`() {
+		assertEquals("""'s S9+256GB..._\m/""", DeviceInfo("","""Ã‘Ã¡Å¾Ã Å•'s S9+256GB..._\m/""").normalize().name)
 	}
 
 	@Test
-	fun `Keeps normal characters`() {
+	fun `Keeps normal US-ASCII letters & numbers`() {
 		assertEquals("My Awesome Device 123", DeviceInfo("","My Awesome Device 123").normalize().name)
+	}
+
+	@Test
+	fun `Keeps normal US-ASCII punctuation & symbols`() {
+		assertEquals("""\ @ ? * - + % & ~ . < = > /""", DeviceInfo("","""\ 吴 @ ඞ ? * - + % & × π ~ . < = > /""").normalize().name)
+	}
+
+	@Test
+	fun `Trims & remove repetitive whitespace`() {
+		assertEquals("""1 2 3 4 5""", DeviceInfo("",""" 1  2   3   4   5     """).normalize().name)
 	}
 }


### PR DESCRIPTION
Now it should work the same way on mobile (device name) as well as on desktop (unit tests).

It also allows the use of some symbols that are part of [US-ASCII](https://en.wikipedia.org/wiki/ASCII#Character_set) and duplicate whitespace are removed.

Context: https://github.com/jellyfin/jellyfin-android/issues/230#issuecomment-724978586