### PR TITLE
Enable explicit API mode in jellyfin-model

### DIFF
--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 }
 
 kotlin {
-	explicitApiWarning()
+	explicitApi()
 }
 
 sourceSets.getByName("main").java.srcDir("src/main/kotlin-generated")

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/ClientInfo.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/ClientInfo.kt
@@ -1,6 +1,6 @@
 package org.jellyfin.apiclient.model
 
-data class ClientInfo(
+public data class ClientInfo(
 	val name: String,
 	val version: String
 )

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/DeviceInfo.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/DeviceInfo.kt
@@ -1,6 +1,6 @@
 package org.jellyfin.apiclient.model
 
-data class DeviceInfo(
+public data class DeviceInfo(
 	val id: String,
 	val name: String
 )

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/discovery/DiscoveryServerInfo.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/discovery/DiscoveryServerInfo.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
  * Contains the information exposed by the server via discovery
  */
 @Serializable
-data class DiscoveryServerInfo(
+public data class DiscoveryServerInfo(
 	/**
 	 * The unique id of this server. Usually a UUID but not guaranteed.
 	 */

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/discovery/ServerVersion.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/discovery/ServerVersion.kt
@@ -8,14 +8,14 @@ import org.jellyfin.apiclient.model.discovery.ServerVersion.Companion.fromString
  * Use [fromString] to parse strings. The format is similar to SemVer.
  */
 @Serializable
-data class ServerVersion(
+public data class ServerVersion(
 	val major: Int,
 	val minor: Int,
 	val patch: Int
 ) {
-	operator fun compareTo(other: ServerVersion) = comparator.compare(this, other)
+	public operator fun compareTo(other: ServerVersion): Int = comparator.compare(this, other)
 
-	companion object {
+	public companion object {
 		private val comparator = compareBy<ServerVersion>(
 			{ it.major },
 			{ it.minor },
@@ -26,7 +26,7 @@ data class ServerVersion(
 		 * Create an instance of [ServerVersion] from a string. The string must be in the format
 		 * "\d+\.\d+\.\d+\". Example: 1.0.0 or 10.6.4. Characters are not allowed.
 		 */
-		fun fromString(str: String): ServerVersion? {
+		public fun fromString(str: String): ServerVersion? {
 			// Split into major, minor and patch
 			val stringParts = str.split('.')
 			// Check if we found 3 parts

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/serializer/LocalDateTimeSerializer.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/serializer/LocalDateTimeSerializer.kt
@@ -14,7 +14,7 @@ import java.time.format.DateTimeParseException
 /**
  * Serializer to read zoned date times as local date time and writing it back
  */
-class LocalDateTimeSerializer : KSerializer<LocalDateTime> {
+public class LocalDateTimeSerializer : KSerializer<LocalDateTime> {
 	override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
 
 	override fun deserialize(decoder: Decoder): LocalDateTime = try {
@@ -25,6 +25,6 @@ class LocalDateTimeSerializer : KSerializer<LocalDateTime> {
 		LocalDateTime.MIN
 	}
 
-	override fun serialize(encoder: Encoder, value: LocalDateTime) =
+	override fun serialize(encoder: Encoder, value: LocalDateTime): Unit =
 		encoder.encodeString(value.atZone(ZoneId.systemDefault()).toString())
 }

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/serializer/UUIDSerializer.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/serializer/UUIDSerializer.kt
@@ -11,7 +11,7 @@ import java.util.*
 /**
  * A UUID serializer that supports the GUIDs without dashes from the Jellyfin API
  */
-class UUIDSerializer : KSerializer<UUID> {
+public class UUIDSerializer : KSerializer<UUID> {
 	override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
 
 	override fun deserialize(decoder: Decoder): UUID {
@@ -25,7 +25,7 @@ class UUIDSerializer : KSerializer<UUID> {
 		encoder.encodeString(value.toString())
 	}
 
-	companion object {
-		val UUID_REGEX = "^([a-z\\d]{8})([a-z\\d]{4})(4[a-z\\d]{3})([a-z\\d]{4})([a-z\\d]{12})\$".toRegex()
+	private companion object {
+		private val UUID_REGEX = "^([a-z\\d]{8})([a-z\\d]{4})(4[a-z\\d]{3})([a-z\\d]{4})([a-z\\d]{12})\$".toRegex()
 	}
 }

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ActivityLogEntryMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ActivityLogEntryMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class ActivityLogEntryMessage(
+public data class ActivityLogEntryMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ActivityLogEntryStartMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ActivityLogEntryStartMessage.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 @SerialName("ActivityLogEntryStart")
-data class ActivityLogEntryStartMessage(
+public data class ActivityLogEntryStartMessage(
 	@SerialName("Data")
 	val period: PeriodicListenerPeriod = PeriodicListenerPeriod(),
 ) : OutgoingSocketMessage

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ActivityLogEntryStopMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ActivityLogEntryStopMessage.kt
@@ -5,4 +5,4 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 @SerialName("ActivityLogEntryStop")
-class ActivityLogEntryStopMessage : OutgoingSocketMessage
+public class ActivityLogEntryStopMessage : OutgoingSocketMessage

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ForceKeepAliveMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ForceKeepAliveMessage.kt
@@ -9,7 +9,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class ForceKeepAliveMessage(
+public data class ForceKeepAliveMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/GeneralCommandMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/GeneralCommandMessage.kt
@@ -9,7 +9,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class GeneralCommandMessage(
+public data class GeneralCommandMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/GeneralCommandType.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/GeneralCommandType.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class GeneralCommandType {
+public enum class GeneralCommandType {
 	@SerialName("MoveUp")
 	MoveUp,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/IncomingSocketMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/IncomingSocketMessage.kt
@@ -7,12 +7,12 @@ import kotlinx.serialization.UseSerializers
 import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
-interface IncomingSocketMessage : SocketMessage {
+public interface IncomingSocketMessage : SocketMessage {
 	/**
 	 * The id of the received message.
 	 *
 	 * Implementation note: Copy the @SerialName notation to the implementation side
 	 */
 	@SerialName("MessageId")
-	val messageId: UUID
+	public val messageId: UUID
 }

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/KeepAliveMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/KeepAliveMessage.kt
@@ -5,4 +5,4 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 @SerialName("KeepAlive")
-class KeepAliveMessage : OutgoingSocketMessage
+public class KeepAliveMessage : OutgoingSocketMessage

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/LibraryChangedMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/LibraryChangedMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class LibraryChangedMessage(
+public data class LibraryChangedMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/OutgoingSocketMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/OutgoingSocketMessage.kt
@@ -1,4 +1,4 @@
 package org.jellyfin.apiclient.model.socket
 
-interface OutgoingSocketMessage : SocketMessage
+public interface OutgoingSocketMessage : SocketMessage
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PackageInstallationCancelledMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PackageInstallationCancelledMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class PackageInstallationCancelledMessage(
+public data class PackageInstallationCancelledMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PackageInstallationCompletedMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PackageInstallationCompletedMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class PackageInstallationCompletedMessage(
+public data class PackageInstallationCompletedMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PackageInstallationFailedMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PackageInstallationFailedMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class PackageInstallationFailedMessage(
+public data class PackageInstallationFailedMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PackageInstallingMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PackageInstallingMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class PackageInstallingMessage(
+public data class PackageInstallingMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PackageUninstalledMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PackageUninstalledMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class PackageUninstalledMessage(
+public data class PackageUninstalledMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PeriodicListenerPeriod.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PeriodicListenerPeriod.kt
@@ -4,11 +4,12 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 @Serializable(with = PeriodicListenerPeriod.Serializer::class)
-data class PeriodicListenerPeriod(
+public data class PeriodicListenerPeriod(
 	val initialDelay: Long = 0,
 	val interval: Long = 1000,
 ) {
@@ -16,8 +17,8 @@ data class PeriodicListenerPeriod(
 		return "$initialDelay,$interval"
 	}
 
-	companion object {
-		fun fromString(str: String): PeriodicListenerPeriod? {
+	public companion object {
+		public 	fun fromString(str: String): PeriodicListenerPeriod? {
 			val values = str.split(',')
 			val dueTimeMs = values.getOrNull(0)?.toLongOrNull() ?: return null
 			val periodMs = values.getOrNull(1)?.toLongOrNull() ?: return null
@@ -29,10 +30,10 @@ data class PeriodicListenerPeriod(
 		}
 	}
 
-	class Serializer : KSerializer<PeriodicListenerPeriod> {
-		override val descriptor = PrimitiveSerialDescriptor("PeriodicListenerPeriod", PrimitiveKind.STRING)
+	public class Serializer : KSerializer<PeriodicListenerPeriod> {
+		override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("PeriodicListenerPeriod", PrimitiveKind.STRING)
 
-		override fun serialize(encoder: Encoder, value: PeriodicListenerPeriod) =
+		override fun serialize(encoder: Encoder, value: PeriodicListenerPeriod): Unit =
 			encoder.encodeString(value.toString())
 
 		override fun deserialize(decoder: Decoder): PeriodicListenerPeriod =

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PlayMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PlayMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class PlayMessage(
+public data class PlayMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PlayStateMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/PlayStateMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class PlayStateMessage(
+public data class PlayStateMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/RefreshProgressMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/RefreshProgressMessage.kt
@@ -9,7 +9,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class RefreshProgressMessage(
+public data class RefreshProgressMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/RestartRequiredMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/RestartRequiredMessage.kt
@@ -9,7 +9,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class RestartRequiredMessage(
+public data class RestartRequiredMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 ) : IncomingSocketMessage

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ScheduledTaskEndedMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ScheduledTaskEndedMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class ScheduledTaskEndedMessage(
+public data class ScheduledTaskEndedMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ScheduledTasksInfoMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ScheduledTasksInfoMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class ScheduledTasksInfoMessage(
+public data class ScheduledTasksInfoMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ScheduledTasksInfoStartMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ScheduledTasksInfoStartMessage.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 @SerialName("ScheduledTasksInfoStart")
-data class ScheduledTasksInfoStartMessage(
+public data class ScheduledTasksInfoStartMessage(
 	@SerialName("Data")
 	val period: PeriodicListenerPeriod = PeriodicListenerPeriod(),
 ) : OutgoingSocketMessage

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ScheduledTasksInfoStopMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ScheduledTasksInfoStopMessage.kt
@@ -5,4 +5,4 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 @SerialName("ScheduledTasksInfoStop")
-class ScheduledTasksInfoStopMessage : OutgoingSocketMessage
+public class ScheduledTasksInfoStopMessage : OutgoingSocketMessage

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SeriesTimerCancelledMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SeriesTimerCancelledMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class SeriesTimerCancelledMessage(
+public data class SeriesTimerCancelledMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SeriesTimerCreatedMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SeriesTimerCreatedMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class SeriesTimerCreatedMessage(
+public data class SeriesTimerCreatedMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ServerRestartingMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ServerRestartingMessage.kt
@@ -9,7 +9,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class ServerRestartingMessage(
+public data class ServerRestartingMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 ) : IncomingSocketMessage

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ServerShuttingDownMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/ServerShuttingDownMessage.kt
@@ -9,7 +9,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class ServerShuttingDownMessage(
+public data class ServerShuttingDownMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 ) : IncomingSocketMessage

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SessionsMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SessionsMessage.kt
@@ -10,9 +10,9 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class SessionsMessage(
+public data class SessionsMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 	@SerialName("Data")
-	val Session: List<SessionInfo>,
+	val session: List<SessionInfo>,
 ) : IncomingSocketMessage

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SessionsStartMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SessionsStartMessage.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 @SerialName("SessionsStart")
-data class SessionsStartMessage(
+public data class SessionsStartMessage(
 	@SerialName("Data")
 	val period: PeriodicListenerPeriod = PeriodicListenerPeriod(),
 ) : OutgoingSocketMessage

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SessionsStopMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SessionsStopMessage.kt
@@ -5,4 +5,4 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 @SerialName("SessionsStart")
-class SessionsStopMessage : OutgoingSocketMessage
+public class SessionsStopMessage : OutgoingSocketMessage

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SocketMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SocketMessage.kt
@@ -1,3 +1,3 @@
 package org.jellyfin.apiclient.model.socket
 
-interface SocketMessage
+public interface SocketMessage

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SyncPlayCommandMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SyncPlayCommandMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class SyncPlayCommandMessage(
+public data class SyncPlayCommandMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SyncPlayGroupUpdateMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/SyncPlayGroupUpdateMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class SyncPlayGroupUpdateMessage(
+public data class SyncPlayGroupUpdateMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/TimerCancelledMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/TimerCancelledMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class TimerCancelledMessage(
+public data class TimerCancelledMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/TimerCreatedMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/TimerCreatedMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class TimerCreatedMessage(
+public data class TimerCreatedMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/UserDataChangedMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/UserDataChangedMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class UserDataChangedMessage(
+public data class UserDataChangedMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 	@SerialName("UserId")

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/UserDeletedMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/UserDeletedMessage.kt
@@ -9,7 +9,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class UserDeletedMessage(
+public data class UserDeletedMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/UserUpdatedMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/socket/UserUpdatedMessage.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.serializer.UUIDSerializer
 import java.util.*
 
 @Serializable
-data class UserUpdatedMessage(
+public data class UserUpdatedMessage(
 	@SerialName("MessageId")
 	override val messageId: UUID,
 


### PR DESCRIPTION
Enables explicit API mode in the jellyfin-model module. Also added some really small naming/comment/error message fixes.

Part of #130 