### PR TITLE
Enable explicit API mode in jellyfin-api

### DIFF
--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 }
 
 kotlin {
-	explicitApiWarning()
+	explicitApi()
 }
 
 sourceSets.getByName("main").java.srcDir("src/main/kotlin-generated")

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/ApiClient.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/ApiClient.kt
@@ -1,13 +1,13 @@
 package org.jellyfin.apiclient.api.client
 
-interface ApiClient {
-	var baseUrl: String?
+public interface ApiClient {
+	public var baseUrl: String?
 
 	/**
 	 * Replaces the variables in a path with the values in the map.
 	 * Will also remove trailing and repeated slashes
 	 */
-	fun createPath(
+	public fun createPath(
 		path: String,
 		pathParameters: Map<String, Any?> = emptyMap()
 	): String
@@ -16,11 +16,11 @@ interface ApiClient {
 	 * Create a complete url based on the [baseUrl] and given parameters.
 	 * Uses [createPath] to create the path
 	 */
-	fun createUrl(
+	public fun createUrl(
 		pathTemplate: String,
 		pathParameters: Map<String, Any?> = emptyMap(),
 		queryParameters: Map<String, Any?> = emptyMap(),
 	): String
 
-	fun createAuthorizationHeader(): String?
+	public fun createAuthorizationHeader(): String?
 }

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/KtorClient.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/KtorClient.kt
@@ -15,20 +15,24 @@ import org.jellyfin.apiclient.model.ClientInfo
 import org.jellyfin.apiclient.model.DeviceInfo
 import kotlin.collections.set
 
-open class KtorClient(
+public open class KtorClient(
 	override var baseUrl: String? = null,
-	var accessToken: String? = null,
-	var clientInfo: ClientInfo,
-	var deviceInfo: DeviceInfo
+	public var accessToken: String? = null,
+	public var clientInfo: ClientInfo,
+	public var deviceInfo: DeviceInfo
 ) : ApiClient {
-	val json = Json {
+	internal val json = Json {
 		isLenient = false
 		ignoreUnknownKeys = true
 		allowSpecialFloatingPointValues = true
 		useArrayPolymorphism = false
 	}
 
-	val client = HttpClient {
+	/**
+	 * Internal HTTP client. Should not be used directly. Use [request] instead.
+	 * Exposed publicly to allow inline functions to work.
+	 */
+	public val client: HttpClient = HttpClient {
 		install(JsonFeature) {
 			serializer = KotlinxSerializer(json)
 		}
@@ -40,7 +44,7 @@ open class KtorClient(
 		install(WebSockets)
 	}
 
-	override fun createPath(path: String, pathParameters: Map<String, Any?>) = path
+	override fun createPath(path: String, pathParameters: Map<String, Any?>): String = path
 		.split('/')
 		.filterNot { it.isEmpty() }
 		.map { rawName ->
@@ -111,7 +115,7 @@ open class KtorClient(
 			})
 	}
 
-	suspend inline fun <reified T> request(
+	public suspend inline fun <reified T> request(
 		method: HttpMethod = HttpMethod.Get,
 		pathTemplate: String,
 		pathParameters: Map<String, Any?> = emptyMap(),
@@ -130,12 +134,12 @@ open class KtorClient(
 		return Response(response.receive(), response.status.value, response.headers.toMap())
 	}
 
-	suspend inline fun <reified T> get(
+	public suspend inline fun <reified T> get(
 		pathTemplate: String,
 		pathParameters: Map<String, Any?> = emptyMap(),
 		queryParameters: Map<String, Any?> = emptyMap(),
 		requestBody: Any? = null
-	) = request<T>(
+	): Response<T> = request(
 		method = HttpMethod.Get,
 		pathTemplate = pathTemplate,
 		pathParameters = pathParameters,
@@ -143,12 +147,12 @@ open class KtorClient(
 		requestBody = requestBody
 	)
 
-	suspend inline fun <reified T> post(
+	public suspend inline fun <reified T> post(
 		pathTemplate: String,
 		pathParameters: Map<String, Any?> = emptyMap(),
 		queryParameters: Map<String, Any?> = emptyMap(),
 		requestBody: Any? = null
-	) = request<T>(
+	): Response<T> = request(
 		method = HttpMethod.Post,
 		pathTemplate = pathTemplate,
 		pathParameters = pathParameters,
@@ -156,12 +160,12 @@ open class KtorClient(
 		requestBody = requestBody
 	)
 
-	suspend inline fun <reified T> delete(
+	public suspend inline fun <reified T> delete(
 		pathTemplate: String,
 		pathParameters: Map<String, Any?> = emptyMap(),
 		queryParameters: Map<String, Any?> = emptyMap(),
 		requestBody: Any? = null
-	) = request<T>(
+	): Response<T> = request(
 		method = HttpMethod.Delete,
 		pathTemplate = pathTemplate,
 		pathParameters = pathParameters,

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/MissingPathVariableError.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/MissingPathVariableError.kt
@@ -1,6 +1,6 @@
 package org.jellyfin.apiclient.api.client
 
-class MissingPathVariableError(
-	name: String,
-	path: String
-) : Error("Missing path variable $name from path $path")
+public class MissingPathVariableError(
+	public val name: String,
+	public val path: String
+) : Error("Missing path variable $name for path $path")

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/Response.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/Response.kt
@@ -8,10 +8,10 @@ import kotlin.reflect.KProperty
  *
  * @param status - See [HttpStatusCode]
  */
-class Response<T>(
-	val content: T,
-	val status: Int,
-	val headers: Map<String, List<String>>
+public class Response<T>(
+	public val content: T,
+	public val status: Int,
+	public val headers: Map<String, List<String>>
 ) {
 	/**
 	 * Get the response content using property delegation.
@@ -21,16 +21,16 @@ class Response<T>(
 	 * ```
 	 */
 	@JvmSynthetic
-	operator fun getValue(thisRef: Any?, property: KProperty<*>): T = content
+	public operator fun getValue(thisRef: Any?, property: KProperty<*>): T = content
 
 	/**
 	 * Get a header by name. If multiple headers with the name exist the first is returned.
 	 * Use [getHeaders] to get all headers with [name].
 	 */
-	fun getHeader(name: String) = headers[name]?.firstOrNull()
+	public fun getHeader(name: String): String? = getHeaders(name).firstOrNull()
 
 	/**
 	 * Get multiple headers sharing the same name. Use [getHeader] to retrieve the first occurrence.
 	 */
-	fun getHeaders(name: String) = headers[name]
+	public fun getHeaders(name: String): List<String> = headers[name].orEmpty()
 }

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/compatibility/JavaCallback.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/compatibility/JavaCallback.kt
@@ -5,9 +5,9 @@ import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
-abstract class JavaCallback<T> : Continuation<Response<T>> {
+public abstract class JavaCallback<T> : Continuation<Response<T>> {
 	override val context: CoroutineContext = EmptyCoroutineContext
-	override fun resumeWith(result: Result<Response<T>>) = onResponse(result.getOrNull())
+	override fun resumeWith(result: Result<Response<T>>): Unit = onResponse(result.getOrNull())
 
-	abstract fun onResponse(response: Response<T>?)
+	public abstract fun onResponse(response: Response<T>?)
 }

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/compatibility/JavaDataCallback.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/compatibility/JavaDataCallback.kt
@@ -5,9 +5,9 @@ import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
-abstract class JavaDataCallback<T> : Continuation<Response<T>> {
+public abstract class JavaDataCallback<T> : Continuation<Response<T>> {
 	override val context: CoroutineContext = EmptyCoroutineContext
-	override fun resumeWith(result: Result<Response<T>>) = onData(result.getOrNull()?.content)
+	override fun resumeWith(result: Result<Response<T>>): Unit = onData(result.getOrNull()?.content)
 
-	abstract fun onData(data: T?)
+	public abstract fun onData(data: T?)
 }

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/extensions/UserApiExtensions.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/extensions/UserApiExtensions.kt
@@ -1,12 +1,17 @@
 package org.jellyfin.apiclient.api.client.extensions
 
+import org.jellyfin.apiclient.api.client.Response
 import org.jellyfin.apiclient.api.operations.UserApi
 import org.jellyfin.apiclient.model.api.AuthenticateUserByName
+import org.jellyfin.apiclient.model.api.AuthenticationResult
 
 /**
  * Extension function for the authenticateUserByName operation that accepts the username and password directly
  */
-suspend inline fun UserApi.authenticateUserByName(username: String, password: String) = authenticateUserByName(
+public suspend inline fun UserApi.authenticateUserByName(
+	username: String,
+	password: String
+): Response<AuthenticationResult> = authenticateUserByName(
 	data = AuthenticateUserByName(
 		username = username,
 		pw = password

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/sockets/SocketSubscription.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/sockets/SocketSubscription.kt
@@ -5,12 +5,12 @@ import org.jellyfin.apiclient.model.socket.IncomingSocketMessage
 /**
  * Subscription to the [WebSocketApi] that can be cancelled.
  */
-class SocketSubscription(
+public class SocketSubscription(
 	private val webSocketApi: WebSocketApi,
 	internal val callback: (IncomingSocketMessage) -> Unit
 ) {
 	/**
 	 * Cancel the subscription and stop listening for messages.
 	 */
-	suspend fun cancel() = webSocketApi.cancelSubscription(this)
+	public suspend fun cancel(): Unit = webSocketApi.cancelSubscription(this)
 }

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/sockets/WebSocketApi.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/sockets/WebSocketApi.kt
@@ -25,12 +25,12 @@ import org.slf4j.LoggerFactory
  *
  * The user should verify the access token is correct as the server does not respond to bad authorization.
  */
-class WebSocketApi(
+public class WebSocketApi(
 	private val api: KtorClient
 ) {
-	companion object {
+	private companion object {
 		// Mapping for types to message
-		val incomingMessageSerializers = mapOf(
+		private val incomingMessageSerializers = mapOf(
 			"ForceKeepAlive" to serializer<ForceKeepAliveMessage>(),
 			"GeneralCommand" to serializer<GeneralCommandMessage>(),
 			"UserDataChanged" to serializer<UserDataChangedMessage>(),
@@ -127,7 +127,7 @@ class WebSocketApi(
 	/**
 	 * Call to (re)connect the WebSocket. Does not close current listeners.
 	 */
-	suspend fun reconnect() {
+	public suspend fun reconnect() {
 		// Get access token and check if it's not null
 		val accessToken = checkNotNull(api.accessToken)
 
@@ -209,12 +209,12 @@ class WebSocketApi(
 	/**
 	 * Publish a message to the server.
 	 */
-	suspend inline fun <reified T : OutgoingSocketMessage> publish(message: T) = publish(message, serializer())
+	public suspend inline fun <reified T : OutgoingSocketMessage> publish(message: T): Unit = publish(message, serializer())
 
 	/**
 	 * Publish a message to the server.
 	 */
-	suspend fun <T : OutgoingSocketMessage> publish(message: T, serializer: KSerializer<T>) {
+	public suspend fun <T : OutgoingSocketMessage> publish(message: T, serializer: KSerializer<T>) {
 		val jsonObject = json.encodeToJsonElement(serializer, message).jsonObject
 		val messageType = serializer.descriptor.serialName
 
@@ -237,7 +237,7 @@ class WebSocketApi(
 	 * Start listening to messages. Calls the [block] for each incoming message until
 	 * [SocketSubscription.cancel] is invoked.
 	 */
-	suspend fun subscribe(block: (IncomingSocketMessage) -> Unit): SocketSubscription {
+	public suspend fun subscribe(block: (IncomingSocketMessage) -> Unit): SocketSubscription {
 		val subscription = SocketSubscription(this, block)
 		subscriptions += subscription
 		subscriptionsChanged()
@@ -248,7 +248,7 @@ class WebSocketApi(
 	/**
 	 * A [Flow] based version of a subscription.
 	 */
-	suspend fun subscribe() = callbackFlow {
+	public suspend fun subscribe(): Flow<IncomingSocketMessage> = callbackFlow {
 		// Create subscription and send messages to flow
 		val subscription = subscribe {
 			sendBlocking(it)
@@ -266,7 +266,7 @@ class WebSocketApi(
 	 * Cancel a subscription by removing it from the API.
 	 * Automatically closes the WebSocket if no subscriptions are left.
 	 */
-	suspend fun cancelSubscription(subscription: SocketSubscription) {
+	public suspend fun cancelSubscription(subscription: SocketSubscription) {
 		subscriptions -= subscription
 		subscriptionsChanged()
 	}


### PR DESCRIPTION
Enables explicit API mode in the jellyfin-api module. Also added some really small naming/comment/error message fixes.

Part of #130 