### PR TITLE
Support font files as binary content in OpenAPI generator

### DIFF
--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiReturnTypeBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiReturnTypeBuilder.kt
@@ -26,6 +26,7 @@ class OpenApiReturnTypeBuilder(
 			MimeType.AUDIO_ALL in supportedReturnMimeTypes ||
 			MimeType.VIDEO_ALL in supportedReturnMimeTypes ||
 			MimeType.IMAGE_ALL in supportedReturnMimeTypes ||
+			MimeType.FONT_ALL in supportedReturnMimeTypes ||
 			MimeType.APPLICATION_X_MPEG_URL in supportedReturnMimeTypes ||
 			MimeType.APPLICATION_OCTET_STREAM in supportedReturnMimeTypes ->
 				TYPE_BINARY

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/MimeType.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/MimeType.kt
@@ -9,6 +9,7 @@ object MimeType {
 	const val IMAGE_ALL = "image/*"
 	const val AUDIO_ALL = "audio/*"
 	const val VIDEO_ALL = "video/*"
+	const val FONT_ALL = "font/*"
 	const val APPLICATION_X_JAVASCRIPT = "application/x-javascript"
 	const val APPLICATION_X_MPEG_URL = "application/x-mpegURL"
 	const val APPLICATION_OCTET_STREAM = "application/octet-stream"


### PR DESCRIPTION
@crobibero fixed a bunch of warnings and introduced a new mime for fonts "font/*" in jellyfin/jellyfin#4486.

This PR adds support for fonts by converting them to a binary stream. OpenAPI spec update later.