### PR TITLE
Add download and update tasks for OpenAPI spec

### DIFF
--- a/openapi-generator/README.md
+++ b/openapi-generator/README.md
@@ -11,6 +11,29 @@ language. For example, the "ImageBlurHashes" property in BaseItemDto can be simp
 Map, and therefor a hook is added for it. All these hooks need to be maintained and updated when the
 OpenAPI specification changes.
 
+## Running
+
+The following Gradle tasks can be used to run the generator:
+
+ - **generateSources**  
+   Reads the openapi.json files and generates Kotlin source code.
+ - **downloadApiSpecStable & downloadApiSpecUnstable**  
+   Downloads the openapi.json file from repo.jellyfin.org.
+ - **updateApiSpecStable & updateApiSpecUnstable**  
+   Runs the download task followed by the generateSources task.
+
+## Updating the repository
+
+When the repository needs to be updated for a new OpenAPI file the following shell commands are
+used:
+
+```sh
+gradlew openapi-generator:updateApiSpecStable
+git add .
+git commit -m "Update generated sources"
+git push
+```
+
 ## Hooks
 
 Hooks are classes that will modify the output of the generator. They should be registered in the
@@ -18,8 +41,8 @@ Hooks are classes that will modify the output of the generator. They should be r
 
   - **TypeBuilderHook**  
     A hook that can intercept the TypeBuilder which converts OpenAPI schemas to Kotlin types. It
-    receives the schema and a type path. The path is unique across the whole document and can be used
-    to identified specific properties. This hook is called when generating types for:
+    receives the schema and a type path. The path is unique across the whole document and can be
+    used to identified specific properties. This hook is called when generating types for:
     
       - model properties
       - api operation parameters
@@ -27,9 +50,9 @@ Hooks are classes that will modify the output of the generator. They should be r
       - api operation return types
 
   - **OperationUrlHook**
-    A hook that can request a url function to be added for an API operation. It receives the model for
-    a complete api service and a single operation. If any hook returns `true` the generator will add
-    a special function called `[operation]Url` (like "GetImageUrl") that will return a string
+    A hook that can request a url function to be added for an API operation. It receives the model
+    for a complete api service and a single operation. If any hook returns `true` the generator will
+    add a special function called `[operation]Url` (like "GetImageUrl") that will return a string
     containing the request url. 
 
 ## Phases

--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
 	kotlin("jvm")
 	id("application")
+
+	id("de.undercouch.download")
 }
 
 application {
@@ -30,13 +32,25 @@ dependencies {
 	testImplementation(Dependencies.Kotlin.Test.junit)
 }
 
-task("generateSources", JavaExec::class) {
+val openApiFile = file("../openapi.json")
+tasks.register("generateSources", JavaExec::class) {
 	main = application.mainClassName
 	classpath = sourceSets.main.get().runtimeClasspath
 
 	args = mapOf(
-		"openApiFile" to file("../openapi.json"),
+		"openApiFile" to openApiFile,
 		"apiOutputDir" to file("../jellyfin-api/src/main/kotlin-generated"),
 		"modelsOutputDir" to file("../jellyfin-model/src/main/kotlin-generated")
 	).map { listOf("--${it.key}", it.value.toString()) }.flatten()
+}
+
+arrayOf("stable", "unstable").forEach { flavor ->
+	tasks.register("downloadApiSpec${flavor.capitalize()}", de.undercouch.gradle.tasks.download.Download::class) {
+		src("https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-${flavor}.json")
+		dest(openApiFile)
+	}
+
+	tasks.register("updateApiSpec${flavor.capitalize()}") {
+		dependsOn("downloadApiSpec${flavor.capitalize()}", "generateSources")
+	}
 }

--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -1,3 +1,5 @@
+import de.undercouch.gradle.tasks.download.Download
+
 plugins {
 	kotlin("jvm")
 	id("application")
@@ -45,7 +47,7 @@ tasks.register("generateSources", JavaExec::class) {
 }
 
 arrayOf("stable", "unstable").forEach { flavor ->
-	tasks.register("downloadApiSpec${flavor.capitalize()}", de.undercouch.gradle.tasks.download.Download::class) {
+	tasks.register("downloadApiSpec${flavor.capitalize()}", Download::class) {
 		src("https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-${flavor}.json")
 		dest(openApiFile)
 	}


### PR DESCRIPTION
Uses repo.jellyfin.org to retrieve stable/unstable specs

- `downloadApiSpecStable` - downloads https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-stable.json
- `downloadApiSpecUnstable` - downloads https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-unstable.json
- `updateApiSpecStable` - runs `downloadApiSpecStable` and then `generateSources`
- `updateApiSpecUnstable` - runs `downloadApiSpecUnstable` and then `generateSources`

_Maybe I should add a task to automatically make commits too_