### PR TITLE
Support nullable parameters in path

### DIFF
--- a/jellyfin-api/src/test/kotlin/org/jellyfin/apiclient/api/client/KtorClientTests.kt
+++ b/jellyfin-api/src/test/kotlin/org/jellyfin/apiclient/api/client/KtorClientTests.kt
@@ -6,11 +6,11 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 
-class KtorClientTests {
+public class KtorClientTests {
 	private fun createClient() = KtorClient("https://demo.jellyfin.org/stable/", null, ClientInfo("Test", "0"), DeviceInfo("test", "test"))
 
 	@Test
-	fun `createPath replaces values`() {
+	public fun `createPath replaces values`() {
 		val instance = createClient()
 		val path = "/test/{one}/{two}/three"
 		val parameters = mapOf(
@@ -23,7 +23,7 @@ class KtorClientTests {
 	}
 
 	@Test
-	fun `createPath removes repeated slashes`() {
+	public fun `createPath removes repeated slashes`() {
 		val instance = createClient()
 		val path = "test/1//2////three"
 
@@ -31,7 +31,7 @@ class KtorClientTests {
 	}
 
 	@Test
-	fun `createPath fails when parameters are missing`() {
+	public fun `createPath fails when parameters are missing`() {
 		val instance = createClient()
 		val path = "/test/{one}/{two}/three"
 		val parameters = mapOf(
@@ -43,7 +43,7 @@ class KtorClientTests {
 	}
 
 	@Test
-	fun `createPath replaces integers`() {
+	public fun `createPath replaces integers`() {
 		val instance = createClient()
 		val path = "/test/{one}/{two}/three"
 		val parameters = mapOf(
@@ -56,7 +56,7 @@ class KtorClientTests {
 	}
 
 	@Test
-	fun `createPath escapes values`() {
+	public fun `createPath escapes values`() {
 		val instance = createClient()
 		val path = "/test/{one}/{two}/three"
 		val parameters = mapOf(
@@ -66,5 +66,18 @@ class KtorClientTests {
 		)
 
 		assertEquals("test/1%2F0/value+with+whitespace/three", instance.createPath(path, parameters))
+	}
+
+	@Test
+	public fun `createPath removes null values`() {
+		val instance = createClient()
+		val path = "/test/{foo}/{bar}/{baz}"
+		val parameters = mapOf(
+			"foo" to "foo",
+			"bar" to null,
+			"baz" to "baz"
+		)
+
+		assertEquals("test/foo/baz", instance.createPath(path, parameters))
 	}
 }

--- a/jellyfin-model/src/test/kotlin/org/jellyfin/apiclient/model/discovery/ServerVersionTests.kt
+++ b/jellyfin-model/src/test/kotlin/org/jellyfin/apiclient/model/discovery/ServerVersionTests.kt
@@ -5,9 +5,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-class ServerVersionTests {
+public class ServerVersionTests {
 	@Test
-	fun `Parses correct version strings`() {
+	public fun `Parses correct version strings`() {
 		assertEquals(ServerVersion.fromString("10.6.4"), ServerVersion(10, 6, 4))
 		assertEquals(ServerVersion.fromString("10.7.0"), ServerVersion(10, 7, 0))
 		assertEquals(ServerVersion.fromString("1.2.3"), ServerVersion(1, 2, 3))
@@ -15,7 +15,7 @@ class ServerVersionTests {
 	}
 
 	@Test
-	fun `Returns null for incorrect version strings`() {
+	public fun `Returns null for incorrect version strings`() {
 		assertNull(ServerVersion.fromString("10.6.4-2"))
 		assertNull(ServerVersion.fromString("10.6.4.2"))
 		assertNull(ServerVersion.fromString("10.7"))
@@ -25,7 +25,7 @@ class ServerVersionTests {
 	}
 
 	@Test
-	fun `Compares to other versions`() {
+	public fun `Compares to other versions`() {
 		assertTrue { ServerVersion(10, 6, 0) == ServerVersion(10, 6, 0) }
 
 		assertTrue { ServerVersion(10, 6, 0) < ServerVersion(10, 6, 1) }

--- a/jellyfin-model/src/test/kotlin/org/jellyfin/apiclient/model/serializer/UUIDSerializerTests.kt
+++ b/jellyfin-model/src/test/kotlin/org/jellyfin/apiclient/model/serializer/UUIDSerializerTests.kt
@@ -5,20 +5,32 @@ import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class UUIDSerializerTests {
+public class UUIDSerializerTests {
 	@Test
-	fun `Parses correctly formatted UUIDs`() {
+	public fun `Parses correctly formatted UUIDs`() {
 		val instance = UUIDSerializer()
 
-		assertEquals(UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"), Json.decodeFromString(instance, "\"713dc3fe-952b-438f-a70e-d35e4ef0525a\""))
-		assertEquals(UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"), Json.decodeFromString(instance, "\"713dc3fe-952b-438f-a70e-d35e4ef0525a\""))
+		assertEquals(
+			UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"),
+			Json.decodeFromString(instance, "\"713dc3fe-952b-438f-a70e-d35e4ef0525a\"")
+		)
+		assertEquals(
+			UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"),
+			Json.decodeFromString(instance, "\"713dc3fe-952b-438f-a70e-d35e4ef0525a\"")
+		)
 	}
 
 	@Test
-	fun `Parses UUIDs formatted without dashes`() {
+	public fun `Parses UUIDs formatted without dashes`() {
 		val instance = UUIDSerializer()
 
-		assertEquals(UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"), Json.decodeFromString(instance, "\"713dc3fe952b438fa70ed35e4ef0525a\""))
-		assertEquals(UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"), Json.decodeFromString(instance, "\"713dc3fe952b438fa70ed35e4ef0525a\""))
+		assertEquals(
+			UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"),
+			Json.decodeFromString(instance, "\"713dc3fe952b438fa70ed35e4ef0525a\"")
+		)
+		assertEquals(
+			UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"),
+			Json.decodeFromString(instance, "\"713dc3fe952b438fa70ed35e4ef0525a\"")
+		)
 	}
 }


### PR DESCRIPTION
- Support `null` as value for a path parameter
  - According to server devs we need to remove it from the path
- Added one additional test for nullable parameters
- Updated all tests to use public visibility - otherwise the IDE will complain because of strictApiMode
- Formatted some tests to make Detekt happy