### PR TITLE
Enable explicit API mode in jellyfin-platform-android

### DIFF
--- a/jellyfin-platform-android/build.gradle.kts
+++ b/jellyfin-platform-android/build.gradle.kts
@@ -28,6 +28,9 @@ android {
 
 	kotlinOptions {
 		jvmTarget = JavaVersion.VERSION_1_8.toString()
+		// The Android DSL doesn't support the explicitApi() function
+		// so we need to add it to the compiler arguments
+		freeCompilerArgs += "-Xexplicit-api=strict"
 	}
 
 	sourceSets["main"].java.srcDirs("src/main/kotlin")

--- a/jellyfin-platform-android/src/main/kotlin/org/jellyfin/apiclient/JellyfinAndroid.kt
+++ b/jellyfin-platform-android/src/main/kotlin/org/jellyfin/apiclient/JellyfinAndroid.kt
@@ -8,7 +8,7 @@ import org.jellyfin.apiclient.interaction.androidDevice
  * Add default Android configuration.
  * Only run after setting the logger.
  */
-fun JellyfinOptions.Builder.android(context: Context) {
+public fun JellyfinOptions.Builder.android(context: Context) {
 	discoveryBroadcastAddressesProvider = AndroidBroadcastAddressesProvider(context)
 	deviceInfo = androidDevice(context)
 }

--- a/jellyfin-platform-android/src/main/kotlin/org/jellyfin/apiclient/discovery/AndroidBroadcastAddressesProvider.kt
+++ b/jellyfin-platform-android/src/main/kotlin/org/jellyfin/apiclient/discovery/AndroidBroadcastAddressesProvider.kt
@@ -9,7 +9,7 @@ import java.net.InetAddress
 /**
  * A broadcast address provider that uses the WifiManager service to retrieve the broadcast address
  */
-class AndroidBroadcastAddressesProvider(
+public class AndroidBroadcastAddressesProvider(
 	private val context: Context
 ) : DiscoveryBroadcastAddressesProvider {
 	/**

--- a/jellyfin-platform-android/src/main/kotlin/org/jellyfin/apiclient/interaction/AndroidDevice.kt
+++ b/jellyfin-platform-android/src/main/kotlin/org/jellyfin/apiclient/interaction/AndroidDevice.kt
@@ -7,7 +7,7 @@ import android.provider.Settings
 import org.jellyfin.apiclient.model.DeviceInfo
 
 @SuppressLint("HardwareIds")
-fun androidDevice(context: Context): DeviceInfo {
+public fun androidDevice(context: Context): DeviceInfo {
 	val id = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
 
 	// Use name from device settings


### PR DESCRIPTION
Enables explicit API mode in the jellyfin-platform-android module. Had to use a workaround to enable it because the explicitApi() DSL is not supported for Android modules. https://youtrack.jetbrains.com/issue/KT-37652

Part of #130