### PR TITLE
Enable explicit API mode in jellyfin-core

### DIFF
--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
 	id("kotlin")
 }
 
+kotlin {
+	explicitApi()
+}
+
 dependencies {
 	apiProject(":jellyfin-api")
 	apiProject(":jellyfin-model")

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/Jellyfin.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/Jellyfin.kt
@@ -6,12 +6,12 @@ import org.jellyfin.apiclient.model.ClientInfo
 import org.jellyfin.apiclient.model.DeviceInfo
 import org.jellyfin.apiclient.model.discovery.ServerVersion
 
-class Jellyfin(
+public class Jellyfin(
 	private val options: JellyfinOptions
 ) {
-	constructor(initOptions: JellyfinOptions.Builder.() -> Unit) : this(JellyfinOptions.build(initOptions))
+	public constructor(initOptions: JellyfinOptions.Builder.() -> Unit) : this(JellyfinOptions.build(initOptions))
 
-	val discovery by lazy {
+	public val discovery: DiscoveryService by lazy {
 		DiscoveryService(this, options.discoverBroadcastAddressesProvider)
 	}
 
@@ -20,14 +20,18 @@ class Jellyfin(
 	 * The [clientInfo] and [deviceInfo] parameters are required when not passed as option in [JellyfinOptions].
 	 * The [baseUrl] is only required when HTTP calls are made.
 	 */
-	fun createApi(
+	public fun createApi(
 		baseUrl: String? = null,
 		accessToken: String? = null,
 		clientInfo: ClientInfo? = options.clientInfo,
 		deviceInfo: DeviceInfo? = options.deviceInfo
 	): KtorClient {
-		checkNotNull(clientInfo) { "ClientInfo needs to be set when calling createApi() or by providing it when constructing the Jellyfin instance" }
-		checkNotNull(deviceInfo) { "DeviceInfo needs to be set when calling createApi() or by providing it when constructing the Jellyfin instance" }
+		checkNotNull(clientInfo) {
+			"ClientInfo needs to be set when calling createApi() or by providing it when constructing the Jellyfin instance"
+		}
+		checkNotNull(deviceInfo) {
+			"DeviceInfo needs to be set when calling createApi() or by providing it when constructing the Jellyfin instance"
+		}
 
 		return KtorClient(
 			baseUrl,
@@ -37,8 +41,8 @@ class Jellyfin(
 		)
 	}
 
-	companion object {
-		val recommendedVersion = ServerVersion(10, 7, 0)
-		val apiVersion = ServerVersion(10, 7, 0)
+	public companion object {
+		public val recommendedVersion: ServerVersion = ServerVersion(10, 7, 0)
+		public val apiVersion: ServerVersion = ServerVersion(10, 7, 0)
 	}
 }

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/JellyfinOptions.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/JellyfinOptions.kt
@@ -5,25 +5,25 @@ import org.jellyfin.apiclient.discovery.JavaNetBroadcastAddressesProvider
 import org.jellyfin.apiclient.model.ClientInfo
 import org.jellyfin.apiclient.model.DeviceInfo
 
-data class JellyfinOptions(
+public data class JellyfinOptions(
 	val discoverBroadcastAddressesProvider: DiscoveryBroadcastAddressesProvider,
 	val clientInfo: ClientInfo?,
 	val deviceInfo: DeviceInfo?
 ) {
-	class Builder {
-		var discoveryBroadcastAddressesProvider: DiscoveryBroadcastAddressesProvider = JavaNetBroadcastAddressesProvider()
-		var clientInfo: ClientInfo? = null
-		var deviceInfo: DeviceInfo? = null
+	public class Builder {
+		public var discoveryBroadcastAddressesProvider: DiscoveryBroadcastAddressesProvider = JavaNetBroadcastAddressesProvider()
+		public var clientInfo: ClientInfo? = null
+		public var deviceInfo: DeviceInfo? = null
 
-		fun build() = JellyfinOptions(
+		public fun build(): JellyfinOptions = JellyfinOptions(
 			discoveryBroadcastAddressesProvider,
 			clientInfo,
 			deviceInfo
 		)
 	}
 
-	companion object {
-		fun build(init: Builder.() -> Unit)= Builder().run {
+	public companion object {
+		public fun build(init: Builder.() -> Unit): JellyfinOptions = Builder().run {
 			init()
 			build()
 		}

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/AddressCandidateHelper.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/AddressCandidateHelper.kt
@@ -6,24 +6,24 @@ import org.slf4j.LoggerFactory
 /**
  * Parses the given [input] and allows to fix common mistakes.
  */
-class AddressCandidateHelper(
+public class AddressCandidateHelper(
 	private val input: String
 ) {
-	companion object {
+	public companion object {
 		/**
 		 * Default HTTP port for Jellyfin
 		 */
-		const val JF_HTTP_PORT = 8096
+		public const val JF_HTTP_PORT: Int = 8096
 
 		/**
 		 * Default HTTPS port for Jellyfin
 		 */
-		const val JF_HTTPS_PORT = 8920
+		public const val JF_HTTPS_PORT: Int = 8920
 
 		/**
 		 * Default base url for Jellyfin
 		 */
-		const val JF_BASE_URL = "/jellyfin/"
+		public const val JF_BASE_URL: String = "/jellyfin/"
 	}
 
 	private val candidates = mutableListOf<Url>()
@@ -52,7 +52,7 @@ class AddressCandidateHelper(
 	/**
 	 * Add a HTTPS candidate for each HTTP candidate
 	 */
-	fun addProtocolCandidates() {
+	public fun addProtocolCandidates() {
 		logger.debug("Adding protocol candidates")
 
 		// Add HTTPS candidate for each HTTP candidate
@@ -67,7 +67,7 @@ class AddressCandidateHelper(
 	 * Add a candidate using Jellyfin ports for each candidate without a specified port or
 	 * protocol-default port.
 	 */
-	fun addPortCandidates() {
+	public fun addPortCandidates() {
 		logger.debug("Adding port candidates")
 
 		// Add HTTPS candidate for each HTTP candidate
@@ -89,7 +89,7 @@ class AddressCandidateHelper(
 	/**
 	 * Add a base url ([JF_BASE_URL]) for each candidate with a root or no path.
 	 */
-	fun addBaseUrlCandidates() {
+	public fun addBaseUrlCandidates() {
 		logger.debug("Adding base url candidates")
 
 		candidates
@@ -109,7 +109,7 @@ class AddressCandidateHelper(
 	 *
 	 *   - BaseUrl
 	 */
-	fun addCommonCandidates() {
+	public fun addCommonCandidates() {
 		logger.debug("Adding common candidates")
 
 		addProtocolCandidates()
@@ -143,7 +143,7 @@ class AddressCandidateHelper(
 	 *   - HTTPS above HTTP
 	 *   - Jellyfin ports above default ports
 	 */
-	fun prioritize() {
+	public fun prioritize() {
 		logger.debug("Prioritizing candidates")
 		candidates.sortWith(prioritizeComparator)
 	}
@@ -152,7 +152,7 @@ class AddressCandidateHelper(
 	 * Get all deduplicated candidate URLs as strings.
 	 * Call [prioritize] before if a sorted list is desired.
 	 */
-	fun getCandidates(): List<String> = candidates
+	public fun getCandidates(): List<String> = candidates
 		.map { it.toString() }
 		.distinct()
 }

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/DiscoveryBroadcastAddressesProvider.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/DiscoveryBroadcastAddressesProvider.kt
@@ -6,9 +6,9 @@ import java.net.InetAddress
  * Broadcast address provider definition that can be implemented to support different platforms for
  * server discovery.
  */
-interface DiscoveryBroadcastAddressesProvider {
+public interface DiscoveryBroadcastAddressesProvider {
 	/**
 	 * Provide broadcast addresses
 	 */
-	suspend fun getBroadcastAddresses(): Collection<InetAddress>
+	public suspend fun getBroadcastAddresses(): Collection<InetAddress>
 }

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/DiscoveryService.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/DiscoveryService.kt
@@ -1,12 +1,14 @@
 package org.jellyfin.apiclient.discovery
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.takeWhile
 import org.jellyfin.apiclient.Jellyfin
+import org.jellyfin.apiclient.model.discovery.DiscoveryServerInfo
 
 /**
  * Service for discovery related functionality
  */
-class DiscoveryService(
+public class DiscoveryService(
 	private val jellyfin: Jellyfin,
 	private val discoveryBroadcastAddressesProvider: DiscoveryBroadcastAddressesProvider
 ) {
@@ -28,7 +30,7 @@ class DiscoveryService(
 	 * The returned candidates are in order of most secure followed by most likely to work.
 	 * See [AddressCandidateHelper] for more information.
 	 */
-	fun getAddressCandidates(input: String) = AddressCandidateHelper(input).run {
+	public fun getAddressCandidates(input: String): List<String> = AddressCandidateHelper(input).run {
 		addCommonCandidates()
 		prioritize()
 		getCandidates()
@@ -50,11 +52,11 @@ class DiscoveryService(
 	 *
 	 * Optionally use [getRecommendedServer] to make this selection automatically.
 	 */
-	suspend fun getRecommendedServers(
+	public suspend fun getRecommendedServers(
 		servers: List<String>,
 		includeAppendedServers: Boolean = true,
 		minimumScore: RecommendedServerInfoScore = RecommendedServerInfoScore.BAD
-	) = recommendedServerDiscovery.discover(
+	): Flow<RecommendedServerInfo> = recommendedServerDiscovery.discover(
 		servers = servers,
 		includeAppendedServers = includeAppendedServers,
 		minimumScore = minimumScore
@@ -63,11 +65,11 @@ class DiscoveryService(
 	/**
 	 * Utility function that calls [getRecommendedServers] with the output of [getAddressCandidates].
 	 */
-	suspend fun getRecommendedServers(
+	public suspend fun getRecommendedServers(
 		input: String,
 		includeAppendedServers: Boolean = true,
 		minimumScore: RecommendedServerInfoScore = RecommendedServerInfoScore.BAD
-	) = getRecommendedServers(
+	): Flow<RecommendedServerInfo> = getRecommendedServers(
 		servers = getAddressCandidates(input),
 		includeAppendedServers = includeAppendedServers,
 		minimumScore = minimumScore
@@ -78,7 +80,7 @@ class DiscoveryService(
 	 * best candidate. Returns when a server with a score of [RecommendedServerInfoScore.GOOD] is
 	 * found or otherwise collects all servers and returns the best one based on order and score.
 	 */
-	suspend fun getRecommendedServer(
+	public suspend fun getRecommendedServer(
 		servers: List<String>,
 		includeAppendedServers: Boolean = true
 	): RecommendedServerInfo? {
@@ -100,10 +102,10 @@ class DiscoveryService(
 	 * Discover servers on the local network. Uses the [discoveryBroadcastAddressesProvider] to
 	 * find local devices to query.
 	 */
-	fun discoverLocalServers(
+	public fun discoverLocalServers(
 		timeout: Int = LocalServerDiscovery.DISCOVERY_TIMEOUT,
 		maxServers: Int = LocalServerDiscovery.DISCOVERY_MAX_SERVERS
-	) = localServerDiscovery.discover(
+	): Flow<DiscoveryServerInfo> = localServerDiscovery.discover(
 		timeout = timeout,
 		maxServers = maxServers
 	)

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/JavaNetBroadcastAddressesProvider.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/JavaNetBroadcastAddressesProvider.kt
@@ -1,13 +1,16 @@
 package org.jellyfin.apiclient.discovery
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.net.InetAddress
 import java.net.NetworkInterface
 
 /**
  * A broadcast address provider that works in the default JVM but not on Android
  */
-class JavaNetBroadcastAddressesProvider : DiscoveryBroadcastAddressesProvider {
-	override suspend fun getBroadcastAddresses(): Collection<InetAddress> =
+public class JavaNetBroadcastAddressesProvider : DiscoveryBroadcastAddressesProvider {
+	@Suppress("BlockingMethodInNonBlockingContext")
+	override suspend fun getBroadcastAddresses(): Collection<InetAddress> = withContext(Dispatchers.IO) {
 		NetworkInterface.getNetworkInterfaces().toList()
 			.filter { !it.isLoopback && it.isUp }
 			.flatMap { networkInterface ->
@@ -15,4 +18,5 @@ class JavaNetBroadcastAddressesProvider : DiscoveryBroadcastAddressesProvider {
 					address.broadcast
 				}
 			}
+	}
 }

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/LocalServerDiscovery.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/LocalServerDiscovery.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.apiclient.discovery
 
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.isActive
 import kotlinx.serialization.SerializationException
@@ -19,15 +20,15 @@ import java.net.SocketTimeoutException
  * Use the [discover] function to retrieve a flow of servers until the timeout is exceeded or
  * the maximum amount of servers has been retrieved.
  */
-class LocalServerDiscovery(
+public class LocalServerDiscovery(
 	private val discoveryBroadcastAddressesProvider: DiscoveryBroadcastAddressesProvider = JavaNetBroadcastAddressesProvider()
 ) {
-	companion object {
-		const val DISCOVERY_MESSAGE = "who is JellyfinServer?"
-		const val DISCOVERY_PORT = 7359
-		const val DISCOVERY_RECEIVE_BUFFER = 1024 // bytes
-		const val DISCOVERY_TIMEOUT = 30 // seconds
-		const val DISCOVERY_MAX_SERVERS = 15
+	public companion object {
+		public const val DISCOVERY_MESSAGE: String = "who is JellyfinServer?"
+		public const val DISCOVERY_PORT: Int = 7359
+		public const val DISCOVERY_RECEIVE_BUFFER: Int = 1024 // bytes
+		public const val DISCOVERY_TIMEOUT: Int = 30 // seconds
+		public const val DISCOVERY_MAX_SERVERS: Int = 15
 	}
 
 	private val logger = LoggerFactory.getLogger("LocalServerDiscovery")
@@ -83,10 +84,10 @@ class LocalServerDiscovery(
 	/**
 	 * Discover servers on the local network
 	 */
-	fun discover(
+	public fun discover(
 		timeout: Int = DISCOVERY_TIMEOUT,
 		maxServers: Int = DISCOVERY_MAX_SERVERS
-	) = flow {
+	): Flow<DiscoveryServerInfo> = flow {
 		logger.info("Starting discovery with timeout of ${timeout}ms")
 
 		val socket = DatagramSocket().apply {

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/RecommendedServerDiscovery.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/RecommendedServerDiscovery.kt
@@ -10,7 +10,7 @@ import org.jellyfin.apiclient.model.discovery.ServerVersion
 import org.slf4j.LoggerFactory
 import java.net.ConnectException
 
-class RecommendedServerDiscovery(
+public class RecommendedServerDiscovery(
 	private val jellyfin: Jellyfin
 ) {
 	private val logger = LoggerFactory.getLogger("RecommendedServerDiscovery")
@@ -80,17 +80,17 @@ class RecommendedServerDiscovery(
 		return RecommendedServerInfo(result.address, result.responseTime, score, result.systemInfo, parentResult?.address)
 	}
 
-	suspend fun discover(
+	public suspend fun discover(
 		servers: List<String>,
 		includeAppendedServers: Boolean,
 		minimumScore: RecommendedServerInfoScore
-	) = discover(
+	): Flow<RecommendedServerInfo> = discover(
 		servers = servers.asFlow(),
 		includeAppendedServers = includeAppendedServers,
 		minimumScore = minimumScore
 	)
 
-	suspend fun discover(
+	public suspend fun discover(
 		servers: Flow<String>,
 		includeAppendedServers: Boolean,
 		minimumScore: RecommendedServerInfoScore

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/RecommendedServerInfo.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/RecommendedServerInfo.kt
@@ -2,7 +2,7 @@ package org.jellyfin.apiclient.discovery
 
 import org.jellyfin.apiclient.model.api.PublicSystemInfo
 
-data class RecommendedServerInfo(
+public data class RecommendedServerInfo(
 	val address: String,
 	val responseTime: Long,
 	val score: RecommendedServerInfoScore,
@@ -12,5 +12,5 @@ data class RecommendedServerInfo(
 	/**
 	 * True when this server was not a part of the inputted addresses, false otherwise.
 	 */
-	val isAppended = parent != null
+	val isAppended: Boolean = parent != null
 }

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/RecommendedServerInfoScore.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/RecommendedServerInfoScore.kt
@@ -1,7 +1,7 @@
 package org.jellyfin.apiclient.discovery
 
-enum class RecommendedServerInfoScore(
-	val score: Int
+public enum class RecommendedServerInfoScore(
+	internal val score: Int
 ) {
 	GOOD(1),
 	OK(0),

--- a/jellyfin-core/src/test/kotlin/org/jellyfin/apiclient/discovery/DiscoveryServiceTests.kt
+++ b/jellyfin-core/src/test/kotlin/org/jellyfin/apiclient/discovery/DiscoveryServiceTests.kt
@@ -3,11 +3,11 @@ package org.jellyfin.apiclient.discovery
 import org.jellyfin.apiclient.Jellyfin
 import kotlin.test.Test
 
-class DiscoveryServiceTests {
+public class DiscoveryServiceTests {
 	private fun getInstance() = DiscoveryService(Jellyfin {}, MockDiscoveryBroadcastAddressesProvider())
 
 	@Test
-	fun `getAddressCandidates prefers https`() {
+	public fun `getAddressCandidates prefers https`() {
 		val instance = getInstance()
 
 		assert(instance.getAddressCandidates("demo.jellyfin.org:433/stable/").first().startsWith("https://"))
@@ -15,7 +15,7 @@ class DiscoveryServiceTests {
 	}
 
 	@Test
-	fun `getAddressCandidates adds Jellyfin ports`() {
+	public fun `getAddressCandidates adds Jellyfin ports`() {
 		val instance = getInstance()
 
 		assert(instance.getAddressCandidates("localhost").contains("http://localhost:8096"))
@@ -23,7 +23,7 @@ class DiscoveryServiceTests {
 	}
 
 	@Test
-	fun `getAddressCandidates accepts hostnames`() {
+	public fun `getAddressCandidates accepts hostnames`() {
 		val instance = getInstance()
 
 		assert(instance.getAddressCandidates("localhost").contains("http://localhost"))
@@ -33,7 +33,7 @@ class DiscoveryServiceTests {
 	}
 
 	@Test
-	fun `getAddressCandidates accepts ipv4 addresses`() {
+	public fun `getAddressCandidates accepts ipv4 addresses`() {
 		val instance = getInstance()
 
 		assert(instance.getAddressCandidates("127.0.0.1").contains("http://127.0.0.1"))
@@ -42,7 +42,7 @@ class DiscoveryServiceTests {
 	}
 
 	@Test
-	fun `getAddressCandidates accepts ipv6 addresses`() {
+	public fun `getAddressCandidates accepts ipv6 addresses`() {
 		val instance = getInstance()
 
 		assert(instance.getAddressCandidates("[::1]").contains("http://[::1]"))
@@ -52,7 +52,7 @@ class DiscoveryServiceTests {
 	}
 
 	@Test
-	fun `getAddressCandidates fails on bad input`() {
+	public fun `getAddressCandidates fails on bad input`() {
 		val instance = getInstance()
 
 		assert(instance.getAddressCandidates("::").isEmpty())

--- a/jellyfin-core/src/test/kotlin/org/jellyfin/apiclient/discovery/MockDiscoveryBroadcastAddressesProvider.kt
+++ b/jellyfin-core/src/test/kotlin/org/jellyfin/apiclient/discovery/MockDiscoveryBroadcastAddressesProvider.kt
@@ -2,6 +2,6 @@ package org.jellyfin.apiclient.discovery
 
 import java.net.InetAddress
 
-class MockDiscoveryBroadcastAddressesProvider : DiscoveryBroadcastAddressesProvider {
+public class MockDiscoveryBroadcastAddressesProvider : DiscoveryBroadcastAddressesProvider {
 	override suspend fun getBroadcastAddresses(): Collection<InetAddress> = emptyList()
 }


### PR DESCRIPTION
Enables explicit API mode in the jellyfin-core module. Also fixes a few linter issues and made the JavaNetBroadcastAddressesProvider use the IO coroutine dispatcher.

Part of #130