### PR TITLE
Add option to generate URLs with access token added

### DIFF
--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/AudioApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/AudioApi.kt
@@ -265,6 +265,7 @@ public class AudioApi(
 	 * video stream will be used.
 	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
 	 * @param streamOptions Optional. The streaming options.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getAudioStreamUrl(
 		itemId: UUID,
@@ -315,7 +316,8 @@ public class AudioApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -368,7 +370,8 @@ public class AudioApi(
 		queryParameters["videoStreamIndex"] = videoStreamIndex
 		queryParameters["context"] = context
 		queryParameters["streamOptions"] = streamOptions
-		return api.createUrl("/Audio/{itemId}/stream", pathParameters, queryParameters)
+		return api.createUrl("/Audio/{itemId}/stream", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -614,6 +617,7 @@ public class AudioApi(
 	 * video stream will be used.
 	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
 	 * @param streamOptions Optional. The streaming options.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getAudioStreamByContainerUrl(
 		itemId: UUID,
@@ -664,7 +668,8 @@ public class AudioApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -717,6 +722,7 @@ public class AudioApi(
 		queryParameters["videoStreamIndex"] = videoStreamIndex
 		queryParameters["context"] = context
 		queryParameters["streamOptions"] = streamOptions
-		return api.createUrl("/Audio/{itemId}/stream.{container}", pathParameters, queryParameters)
+		return api.createUrl("/Audio/{itemId}/stream.{container}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 }

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ConfigurationApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ConfigurationApi.kt
@@ -7,6 +7,7 @@ package org.jellyfin.apiclient.api.operations
 
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
+import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
 import org.jellyfin.apiclient.api.client.KtorClient
@@ -59,12 +60,14 @@ public class ConfigurationApi(
 	 * Gets a named configuration.
 	 *
 	 * @param key Configuration key.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getNamedConfigurationUrl(key: String): String {
+	public fun getNamedConfigurationUrl(key: String, includeCredentials: Boolean = false): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["key"] = key
 		val queryParameters = emptyMap<String, Any?>()
-		return api.createUrl("/System/Configuration/{key}", pathParameters, queryParameters)
+		return api.createUrl("/System/Configuration/{key}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/DlnaServerApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/DlnaServerApi.kt
@@ -7,6 +7,7 @@ package org.jellyfin.apiclient.api.operations
 
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
+import kotlin.Boolean
 import kotlin.String
 import org.jellyfin.apiclient.api.client.KtorClient
 import org.jellyfin.apiclient.api.client.Response
@@ -186,13 +187,19 @@ public class DlnaServerApi(
 	 *
 	 * @param serverId Server UUID.
 	 * @param fileName The icon filename.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getIconIdUrl(serverId: String, fileName: String): String {
+	public fun getIconIdUrl(
+		serverId: String,
+		fileName: String,
+		includeCredentials: Boolean = false
+	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["serverId"] = serverId
 		pathParameters["fileName"] = fileName
 		val queryParameters = emptyMap<String, Any?>()
-		return api.createUrl("/Dlna/{serverId}/icons/{fileName}", pathParameters, queryParameters)
+		return api.createUrl("/Dlna/{serverId}/icons/{fileName}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -276,11 +283,13 @@ public class DlnaServerApi(
 	 * Gets a server icon.
 	 *
 	 * @param fileName The icon filename.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getIconUrl(fileName: String): String {
+	public fun getIconUrl(fileName: String, includeCredentials: Boolean = false): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["fileName"] = fileName
 		val queryParameters = emptyMap<String, Any?>()
-		return api.createUrl("/Dlna/icons/{fileName}", pathParameters, queryParameters)
+		return api.createUrl("/Dlna/icons/{fileName}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 }

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/DynamicHlsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/DynamicHlsApi.kt
@@ -280,6 +280,7 @@ public class DynamicHlsApi(
 	 * video stream will be used.
 	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
 	 * @param streamOptions Optional. The streaming options.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getHlsAudioSegmentUrl(
 		itemId: UUID,
@@ -333,7 +334,8 @@ public class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -390,7 +392,7 @@ public class DynamicHlsApi(
 		queryParameters["context"] = context
 		queryParameters["streamOptions"] = streamOptions
 		return api.createUrl("/Audio/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**
@@ -636,6 +638,7 @@ public class DynamicHlsApi(
 	 * video stream will be used.
 	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
 	 * @param streamOptions Optional. The streaming options.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getVariantHlsAudioPlaylistUrl(
 		itemId: UUID,
@@ -686,7 +689,8 @@ public class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -739,7 +743,8 @@ public class DynamicHlsApi(
 		queryParameters["videoStreamIndex"] = videoStreamIndex
 		queryParameters["context"] = context
 		queryParameters["streamOptions"] = streamOptions
-		return api.createUrl("/Audio/{itemId}/main.m3u8", pathParameters, queryParameters)
+		return api.createUrl("/Audio/{itemId}/main.m3u8", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -989,6 +994,7 @@ public class DynamicHlsApi(
 	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
 	 * @param streamOptions Optional. The streaming options.
 	 * @param enableAdaptiveBitrateStreaming Enable adaptive bitrate streaming.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getMasterHlsAudioPlaylistUrl(
 		itemId: UUID,
@@ -1040,7 +1046,8 @@ public class DynamicHlsApi(
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
 		streamOptions: Map<String, String>? = null,
-		enableAdaptiveBitrateStreaming: Boolean
+		enableAdaptiveBitrateStreaming: Boolean,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -1094,7 +1101,8 @@ public class DynamicHlsApi(
 		queryParameters["context"] = context
 		queryParameters["streamOptions"] = streamOptions
 		queryParameters["enableAdaptiveBitrateStreaming"] = enableAdaptiveBitrateStreaming
-		return api.createUrl("/Audio/{itemId}/master.m3u8", pathParameters, queryParameters)
+		return api.createUrl("/Audio/{itemId}/master.m3u8", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -1351,6 +1359,7 @@ public class DynamicHlsApi(
 	 * video stream will be used.
 	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
 	 * @param streamOptions Optional. The streaming options.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getHlsVideoSegmentUrl(
 		itemId: UUID,
@@ -1403,7 +1412,8 @@ public class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -1459,7 +1469,7 @@ public class DynamicHlsApi(
 		queryParameters["context"] = context
 		queryParameters["streamOptions"] = streamOptions
 		return api.createUrl("/Videos/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**
@@ -1701,6 +1711,7 @@ public class DynamicHlsApi(
 	 * video stream will be used.
 	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
 	 * @param streamOptions Optional. The streaming options.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getVariantHlsVideoPlaylistUrl(
 		itemId: UUID,
@@ -1750,7 +1761,8 @@ public class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -1802,7 +1814,8 @@ public class DynamicHlsApi(
 		queryParameters["videoStreamIndex"] = videoStreamIndex
 		queryParameters["context"] = context
 		queryParameters["streamOptions"] = streamOptions
-		return api.createUrl("/Videos/{itemId}/main.m3u8", pathParameters, queryParameters)
+		return api.createUrl("/Videos/{itemId}/main.m3u8", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -2048,6 +2061,7 @@ public class DynamicHlsApi(
 	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
 	 * @param streamOptions Optional. The streaming options.
 	 * @param enableAdaptiveBitrateStreaming Enable adaptive bitrate streaming.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getMasterHlsVideoPlaylistUrl(
 		itemId: UUID,
@@ -2098,7 +2112,8 @@ public class DynamicHlsApi(
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
 		streamOptions: Map<String, String>? = null,
-		enableAdaptiveBitrateStreaming: Boolean
+		enableAdaptiveBitrateStreaming: Boolean,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -2151,6 +2166,7 @@ public class DynamicHlsApi(
 		queryParameters["context"] = context
 		queryParameters["streamOptions"] = streamOptions
 		queryParameters["enableAdaptiveBitrateStreaming"] = enableAdaptiveBitrateStreaming
-		return api.createUrl("/Videos/{itemId}/master.m3u8", pathParameters, queryParameters)
+		return api.createUrl("/Videos/{itemId}/master.m3u8", pathParameters, queryParameters,
+				includeCredentials)
 	}
 }

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/HlsSegmentApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/HlsSegmentApi.kt
@@ -7,6 +7,7 @@ package org.jellyfin.apiclient.api.operations
 
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
+import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
 import org.jellyfin.apiclient.api.client.KtorClient
@@ -38,14 +39,19 @@ public class HlsSegmentApi(
 	 *
 	 * @param itemId The item id.
 	 * @param segmentId The segment id.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getHlsAudioSegmentLegacyAacUrl(itemId: String, segmentId: String): String {
+	public fun getHlsAudioSegmentLegacyAacUrl(
+		itemId: String,
+		segmentId: String,
+		includeCredentials: Boolean = false
+	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
 		pathParameters["segmentId"] = segmentId
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Audio/{itemId}/hls/{segmentId}/stream.aac", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**
@@ -71,14 +77,19 @@ public class HlsSegmentApi(
 	 *
 	 * @param itemId The item id.
 	 * @param segmentId The segment id.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getHlsAudioSegmentLegacyMp3Url(itemId: String, segmentId: String): String {
+	public fun getHlsAudioSegmentLegacyMp3Url(
+		itemId: String,
+		segmentId: String,
+		includeCredentials: Boolean = false
+	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
 		pathParameters["segmentId"] = segmentId
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Audio/{itemId}/hls/{segmentId}/stream.mp3", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**
@@ -115,12 +126,14 @@ public class HlsSegmentApi(
 	 * @param playlistId The playlist id.
 	 * @param segmentId The segment id.
 	 * @param segmentContainer The segment container.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getHlsVideoSegmentLegacyUrl(
 		itemId: String,
 		playlistId: String,
 		segmentId: String,
-		segmentContainer: String
+		segmentContainer: String,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -129,7 +142,7 @@ public class HlsSegmentApi(
 		pathParameters["segmentContainer"] = segmentContainer
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Videos/{itemId}/hls/{playlistId}/{segmentId}.{segmentContainer}",
-				pathParameters, queryParameters)
+				pathParameters, queryParameters, includeCredentials)
 	}
 
 	/**
@@ -155,14 +168,19 @@ public class HlsSegmentApi(
 	 *
 	 * @param itemId The video id.
 	 * @param playlistId The playlist id.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getHlsPlaylistLegacyUrl(itemId: String, playlistId: String): String {
+	public fun getHlsPlaylistLegacyUrl(
+		itemId: String,
+		playlistId: String,
+		includeCredentials: Boolean = false
+	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
 		pathParameters["playlistId"] = playlistId
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Videos/{itemId}/hls/{playlistId}/stream.m3u8", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ImageApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ImageApi.kt
@@ -114,6 +114,7 @@ public class ImageApi(
 	 * @param blur Optional. Blur image.
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getArtistImageUrl(
 		name: String,
@@ -132,7 +133,8 @@ public class ImageApi(
 		addPlayedIndicator: Boolean? = null,
 		blur: Int? = null,
 		backgroundColor: String? = null,
-		foregroundLayer: String? = null
+		foregroundLayer: String? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
@@ -154,7 +156,7 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		return api.createUrl("/Artists/{name}/Images/{imageType}/{imageIndex}", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**
@@ -248,6 +250,7 @@ public class ImageApi(
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
 	 * @param imageIndex Image index.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getGenreImageUrl(
 		name: String,
@@ -266,7 +269,8 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-		imageIndex: Int? = null
+		imageIndex: Int? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
@@ -287,7 +291,8 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		queryParameters["imageIndex"] = imageIndex
-		return api.createUrl("/Genres/{name}/Images/{imageType}", pathParameters, queryParameters)
+		return api.createUrl("/Genres/{name}/Images/{imageType}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -381,6 +386,7 @@ public class ImageApi(
 	 * @param blur Optional. Blur image.
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getGenreImageByIndexUrl(
 		name: String,
@@ -399,7 +405,8 @@ public class ImageApi(
 		addPlayedIndicator: Boolean? = null,
 		blur: Int? = null,
 		backgroundColor: String? = null,
-		foregroundLayer: String? = null
+		foregroundLayer: String? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
@@ -421,7 +428,7 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		return api.createUrl("/Genres/{name}/Images/{imageType}/{imageIndex}", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**
@@ -530,6 +537,7 @@ public class ImageApi(
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
 	 * @param imageIndex Image index.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getItemImageUrl(
 		itemId: UUID,
@@ -548,7 +556,8 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-		imageIndex: Int? = null
+		imageIndex: Int? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -569,7 +578,8 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		queryParameters["imageIndex"] = imageIndex
-		return api.createUrl("/Items/{itemId}/Images/{imageType}", pathParameters, queryParameters)
+		return api.createUrl("/Items/{itemId}/Images/{imageType}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -703,6 +713,7 @@ public class ImageApi(
 	 * @param blur Optional. Blur image.
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getItemImageByIndexUrl(
 		itemId: UUID,
@@ -721,7 +732,8 @@ public class ImageApi(
 		unplayedCount: Int? = null,
 		blur: Int? = null,
 		backgroundColor: String? = null,
-		foregroundLayer: String? = null
+		foregroundLayer: String? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -743,7 +755,7 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		return api.createUrl("/Items/{itemId}/Images/{imageType}/{imageIndex}", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**
@@ -884,6 +896,7 @@ public class ImageApi(
 	 * @param blur Optional. Blur image.
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getItemImage2Url(
 		itemId: UUID,
@@ -902,7 +915,8 @@ public class ImageApi(
 		addPlayedIndicator: Boolean? = null,
 		blur: Int? = null,
 		backgroundColor: String? = null,
-		foregroundLayer: String? = null
+		foregroundLayer: String? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -924,7 +938,7 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		return api.createUrl("/Items/{itemId}/Images/{imageType}/{imageIndex}/{tag}/{format}/{maxWidth}/{maxHeight}/{percentPlayed}/{unplayedCount}",
-				pathParameters, queryParameters)
+				pathParameters, queryParameters, includeCredentials)
 	}
 
 	/**
@@ -1044,6 +1058,7 @@ public class ImageApi(
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
 	 * @param imageIndex Image index.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getMusicGenreImageUrl(
 		name: String,
@@ -1062,7 +1077,8 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-		imageIndex: Int? = null
+		imageIndex: Int? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
@@ -1083,7 +1099,8 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		queryParameters["imageIndex"] = imageIndex
-		return api.createUrl("/MusicGenres/{name}/Images/{imageType}", pathParameters, queryParameters)
+		return api.createUrl("/MusicGenres/{name}/Images/{imageType}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -1177,6 +1194,7 @@ public class ImageApi(
 	 * @param blur Optional. Blur image.
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getMusicGenreImageByIndexUrl(
 		name: String,
@@ -1195,7 +1213,8 @@ public class ImageApi(
 		addPlayedIndicator: Boolean? = null,
 		blur: Int? = null,
 		backgroundColor: String? = null,
-		foregroundLayer: String? = null
+		foregroundLayer: String? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
@@ -1217,7 +1236,7 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		return api.createUrl("/MusicGenres/{name}/Images/{imageType}/{imageIndex}", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**
@@ -1311,6 +1330,7 @@ public class ImageApi(
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
 	 * @param imageIndex Image index.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getPersonImageUrl(
 		name: String,
@@ -1329,7 +1349,8 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-		imageIndex: Int? = null
+		imageIndex: Int? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
@@ -1350,7 +1371,8 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		queryParameters["imageIndex"] = imageIndex
-		return api.createUrl("/Persons/{name}/Images/{imageType}", pathParameters, queryParameters)
+		return api.createUrl("/Persons/{name}/Images/{imageType}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -1444,6 +1466,7 @@ public class ImageApi(
 	 * @param blur Optional. Blur image.
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getPersonImageByIndexUrl(
 		name: String,
@@ -1462,7 +1485,8 @@ public class ImageApi(
 		addPlayedIndicator: Boolean? = null,
 		blur: Int? = null,
 		backgroundColor: String? = null,
-		foregroundLayer: String? = null
+		foregroundLayer: String? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
@@ -1484,7 +1508,7 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		return api.createUrl("/Persons/{name}/Images/{imageType}/{imageIndex}", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**
@@ -1578,6 +1602,7 @@ public class ImageApi(
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
 	 * @param imageIndex Image index.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getStudioImageUrl(
 		name: String,
@@ -1596,7 +1621,8 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-		imageIndex: Int? = null
+		imageIndex: Int? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
@@ -1617,7 +1643,8 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		queryParameters["imageIndex"] = imageIndex
-		return api.createUrl("/Studios/{name}/Images/{imageType}", pathParameters, queryParameters)
+		return api.createUrl("/Studios/{name}/Images/{imageType}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -1711,6 +1738,7 @@ public class ImageApi(
 	 * @param blur Optional. Blur image.
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getStudioImageByIndexUrl(
 		name: String,
@@ -1729,7 +1757,8 @@ public class ImageApi(
 		addPlayedIndicator: Boolean? = null,
 		blur: Int? = null,
 		backgroundColor: String? = null,
-		foregroundLayer: String? = null
+		foregroundLayer: String? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
@@ -1751,7 +1780,7 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		return api.createUrl("/Studios/{name}/Images/{imageType}/{imageIndex}", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**
@@ -1845,6 +1874,7 @@ public class ImageApi(
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
 	 * @param imageIndex Image index.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getUserImageUrl(
 		userId: UUID,
@@ -1863,7 +1893,8 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-		imageIndex: Int? = null
+		imageIndex: Int? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["userId"] = userId
@@ -1884,7 +1915,8 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		queryParameters["imageIndex"] = imageIndex
-		return api.createUrl("/Users/{userId}/Images/{imageType}", pathParameters, queryParameters)
+		return api.createUrl("/Users/{userId}/Images/{imageType}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -2024,6 +2056,7 @@ public class ImageApi(
 	 * @param blur Optional. Blur image.
 	 * @param backgroundColor Optional. Apply a background color for transparent images.
 	 * @param foregroundLayer Optional. Apply a foreground layer on top of the image.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getUserImageByIndexUrl(
 		userId: UUID,
@@ -2042,7 +2075,8 @@ public class ImageApi(
 		addPlayedIndicator: Boolean? = null,
 		blur: Int? = null,
 		backgroundColor: String? = null,
-		foregroundLayer: String? = null
+		foregroundLayer: String? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["userId"] = userId
@@ -2064,7 +2098,7 @@ public class ImageApi(
 		queryParameters["backgroundColor"] = backgroundColor
 		queryParameters["foregroundLayer"] = foregroundLayer
 		return api.createUrl("/Users/{userId}/Images/{imageType}/{imageIndex}", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ImageByNameApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ImageByNameApi.kt
@@ -7,6 +7,7 @@ package org.jellyfin.apiclient.api.operations
 
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
+import kotlin.Boolean
 import kotlin.String
 import kotlin.collections.List
 import org.jellyfin.apiclient.api.client.KtorClient
@@ -50,13 +51,19 @@ public class ImageByNameApi(
 	 *
 	 * @param name The name of the image.
 	 * @param type Image Type (primary, backdrop, logo, etc).
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getGeneralImageUrl(name: String, type: String): String {
+	public fun getGeneralImageUrl(
+		name: String,
+		type: String,
+		includeCredentials: Boolean = false
+	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
 		pathParameters["type"] = type
 		val queryParameters = emptyMap<String, Any?>()
-		return api.createUrl("/Images/General/{name}/{type}", pathParameters, queryParameters)
+		return api.createUrl("/Images/General/{name}/{type}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -93,13 +100,19 @@ public class ImageByNameApi(
 	 *
 	 * @param theme The theme to get the image from.
 	 * @param name The name of the image.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getMediaInfoImageUrl(theme: String, name: String): String {
+	public fun getMediaInfoImageUrl(
+		theme: String,
+		name: String,
+		includeCredentials: Boolean = false
+	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["theme"] = theme
 		pathParameters["name"] = name
 		val queryParameters = emptyMap<String, Any?>()
-		return api.createUrl("/Images/MediaInfo/{theme}/{name}", pathParameters, queryParameters)
+		return api.createUrl("/Images/MediaInfo/{theme}/{name}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -136,12 +149,18 @@ public class ImageByNameApi(
 	 *
 	 * @param theme The theme to get the image from.
 	 * @param name The name of the image.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getRatingImageUrl(theme: String, name: String): String {
+	public fun getRatingImageUrl(
+		theme: String,
+		name: String,
+		includeCredentials: Boolean = false
+	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["theme"] = theme
 		pathParameters["name"] = name
 		val queryParameters = emptyMap<String, Any?>()
-		return api.createUrl("/Images/Ratings/{theme}/{name}", pathParameters, queryParameters)
+		return api.createUrl("/Images/Ratings/{theme}/{name}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 }

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ItemLookupApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/ItemLookupApi.kt
@@ -111,13 +111,19 @@ public class ItemLookupApi(
 	 *
 	 * @param imageUrl The image url.
 	 * @param providerName The provider name.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getRemoteSearchImageUrl(imageUrl: String, providerName: String): String {
+	public fun getRemoteSearchImageUrl(
+		imageUrl: String,
+		providerName: String,
+		includeCredentials: Boolean = false
+	): String {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
 		queryParameters["imageUrl"] = imageUrl
 		queryParameters["providerName"] = providerName
-		return api.createUrl("/Items/RemoteSearch/Image", pathParameters, queryParameters)
+		return api.createUrl("/Items/RemoteSearch/Image", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LibraryApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LibraryApi.kt
@@ -170,12 +170,14 @@ public class LibraryApi(
 	 * Downloads item media.
 	 *
 	 * @param itemId The item id.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getDownloadUrl(itemId: UUID): String {
+	public fun getDownloadUrl(itemId: UUID, includeCredentials: Boolean = false): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
 		val queryParameters = emptyMap<String, Any?>()
-		return api.createUrl("/Items/{itemId}/Download", pathParameters, queryParameters)
+		return api.createUrl("/Items/{itemId}/Download", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -197,12 +199,13 @@ public class LibraryApi(
 	 * Get the original file of an item.
 	 *
 	 * @param itemId The item id.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getFileUrl(itemId: UUID): String {
+	public fun getFileUrl(itemId: UUID, includeCredentials: Boolean = false): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
 		val queryParameters = emptyMap<String, Any?>()
-		return api.createUrl("/Items/{itemId}/File", pathParameters, queryParameters)
+		return api.createUrl("/Items/{itemId}/File", pathParameters, queryParameters, includeCredentials)
 	}
 
 	/**

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LiveTvApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/LiveTvApi.kt
@@ -286,12 +286,14 @@ public class LiveTvApi(
 
 	/**
 	 * Gets available countries.
+	 *
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getSchedulesDirectCountriesUrl(): String {
+	public fun getSchedulesDirectCountriesUrl(includeCredentials: Boolean = false): String {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/LiveTv/ListingProviders/SchedulesDirect/Countries", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**
@@ -313,13 +315,15 @@ public class LiveTvApi(
 	 * Gets a live tv recording stream.
 	 *
 	 * @param recordingId Recording id.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getLiveRecordingFileUrl(recordingId: String): String {
+	public fun getLiveRecordingFileUrl(recordingId: String, includeCredentials: Boolean = false):
+			String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["recordingId"] = recordingId
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/LiveTv/LiveRecordings/{recordingId}/stream", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**
@@ -345,14 +349,19 @@ public class LiveTvApi(
 	 *
 	 * @param streamId Stream id.
 	 * @param container Container type.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getLiveStreamFileUrl(streamId: String, container: String): String {
+	public fun getLiveStreamFileUrl(
+		streamId: String,
+		container: String,
+		includeCredentials: Boolean = false
+	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["streamId"] = streamId
 		pathParameters["container"] = container
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/LiveTv/LiveStreamFiles/{streamId}/stream.{container}", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 
 	/**

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MediaInfoApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MediaInfoApi.kt
@@ -179,11 +179,12 @@ public class MediaInfoApi(
 	 * Tests the network with a request with the size of the bitrate.
 	 *
 	 * @param size The bitrate. Defaults to 102400.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getBitrateTestBytesUrl(size: Int): String {
+	public fun getBitrateTestBytesUrl(size: Int, includeCredentials: Boolean = false): String {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
 		queryParameters["size"] = size
-		return api.createUrl("/Playback/BitrateTest", pathParameters, queryParameters)
+		return api.createUrl("/Playback/BitrateTest", pathParameters, queryParameters, includeCredentials)
 	}
 }

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/RemoteImageApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/RemoteImageApi.kt
@@ -40,12 +40,13 @@ public class RemoteImageApi(
 	 * Gets a remote image.
 	 *
 	 * @param imageUrl The image url.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getRemoteImageUrl(imageUrl: String): String {
+	public fun getRemoteImageUrl(imageUrl: String, includeCredentials: Boolean = false): String {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
 		queryParameters["imageUrl"] = imageUrl
-		return api.createUrl("/Images/Remote", pathParameters, queryParameters)
+		return api.createUrl("/Images/Remote", pathParameters, queryParameters, includeCredentials)
 	}
 
 	/**

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/SubtitleApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/SubtitleApi.kt
@@ -54,12 +54,14 @@ public class SubtitleApi(
 	 * Gets a fallback font file.
 	 *
 	 * @param name The name of the fallback font file to get.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getFallbackFontUrl(name: String): String {
+	public fun getFallbackFontUrl(name: String, includeCredentials: Boolean = false): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["name"] = name
 		val queryParameters = emptyMap<String, Any?>()
-		return api.createUrl("/FallbackFont/Fonts/{name}", pathParameters, queryParameters)
+		return api.createUrl("/FallbackFont/Fonts/{name}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -230,12 +232,14 @@ public class SubtitleApi(
 	 * @param index The subtitle stream index.
 	 * @param mediaSourceId The media source id.
 	 * @param segmentLength The subtitle segment length.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getSubtitlePlaylistUrl(
 		itemId: UUID,
 		index: Int,
 		mediaSourceId: String,
-		segmentLength: Int
+		segmentLength: Int,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -244,7 +248,7 @@ public class SubtitleApi(
 		val queryParameters = mutableMapOf<String, Any?>()
 		queryParameters["segmentLength"] = segmentLength
 		return api.createUrl("/Videos/{itemId}/{mediaSourceId}/Subtitles/{index}/subtitles.m3u8",
-				pathParameters, queryParameters)
+				pathParameters, queryParameters, includeCredentials)
 	}
 
 	/**

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/UniversalAudioApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/UniversalAudioApi.kt
@@ -112,6 +112,7 @@ public class UniversalAudioApi(
 	 * @param enableRemoteMedia Optional. Whether to enable remote media.
 	 * @param breakOnNonKeyFrames Optional. Whether to break on non key frames.
 	 * @param enableRedirection Whether to enable redirection. Defaults to true.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getUniversalAudioStreamUrl(
 		itemId: UUID,
@@ -131,7 +132,8 @@ public class UniversalAudioApi(
 		maxAudioBitDepth: Int? = null,
 		enableRemoteMedia: Boolean? = null,
 		breakOnNonKeyFrames: Boolean,
-		enableRedirection: Boolean
+		enableRedirection: Boolean,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -153,6 +155,7 @@ public class UniversalAudioApi(
 		queryParameters["enableRemoteMedia"] = enableRemoteMedia
 		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
 		queryParameters["enableRedirection"] = enableRedirection
-		return api.createUrl("/Audio/{itemId}/universal", pathParameters, queryParameters)
+		return api.createUrl("/Audio/{itemId}/universal", pathParameters, queryParameters,
+				includeCredentials)
 	}
 }

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideoAttachmentsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideoAttachmentsApi.kt
@@ -8,6 +8,7 @@ package org.jellyfin.apiclient.api.operations
 import io.ktor.utils.io.ByteReadChannel
 import java.util.UUID
 import kotlin.Any
+import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import org.jellyfin.apiclient.api.client.KtorClient
@@ -45,11 +46,13 @@ public class VideoAttachmentsApi(
 	 * @param videoId Video ID.
 	 * @param mediaSourceId Media Source ID.
 	 * @param index Attachment Index.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getAttachmentUrl(
 		videoId: UUID,
 		mediaSourceId: String,
-		index: Int
+		index: Int,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["videoId"] = videoId
@@ -57,6 +60,6 @@ public class VideoAttachmentsApi(
 		pathParameters["index"] = index
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Videos/{videoId}/{mediaSourceId}/Attachments/{index}", pathParameters,
-				queryParameters)
+				queryParameters, includeCredentials)
 	}
 }

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideoHlsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideoHlsApi.kt
@@ -277,6 +277,7 @@ public class VideoHlsApi(
 	 * @param maxWidth Optional. The max width.
 	 * @param maxHeight Optional. The max height.
 	 * @param enableSubtitlesInManifest Optional. Whether to enable subtitles in the manifest.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getLiveHlsStreamUrl(
 		itemId: UUID,
@@ -330,7 +331,8 @@ public class VideoHlsApi(
 		streamOptions: Map<String, String>? = null,
 		maxWidth: Int? = null,
 		maxHeight: Int? = null,
-		enableSubtitlesInManifest: Boolean? = null
+		enableSubtitlesInManifest: Boolean? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -386,6 +388,7 @@ public class VideoHlsApi(
 		queryParameters["maxWidth"] = maxWidth
 		queryParameters["maxHeight"] = maxHeight
 		queryParameters["enableSubtitlesInManifest"] = enableSubtitlesInManifest
-		return api.createUrl("/Videos/{itemId}/live.m3u8", pathParameters, queryParameters)
+		return api.createUrl("/Videos/{itemId}/live.m3u8", pathParameters, queryParameters,
+				includeCredentials)
 	}
 }

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideosApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideosApi.kt
@@ -272,6 +272,7 @@ public class VideosApi(
 	 * video stream will be used.
 	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
 	 * @param streamOptions Optional. The streaming options.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getVideoStreamByContainerUrl(
 		itemId: UUID,
@@ -323,7 +324,8 @@ public class VideosApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -377,7 +379,8 @@ public class VideosApi(
 		queryParameters["videoStreamIndex"] = videoStreamIndex
 		queryParameters["context"] = context
 		queryParameters["streamOptions"] = streamOptions
-		return api.createUrl("/Videos/{itemId}/{stream}.{container}", pathParameters, queryParameters)
+		return api.createUrl("/Videos/{itemId}/{stream}.{container}", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**
@@ -658,6 +661,7 @@ public class VideosApi(
 	 * video stream will be used.
 	 * @param context Optional. The MediaBrowser.Model.Dlna.EncodingContext.
 	 * @param streamOptions Optional. The streaming options.
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getVideoStreamUrl(
 		itemId: UUID,
@@ -708,7 +712,8 @@ public class VideosApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null
+		streamOptions: Map<String, String>? = null,
+		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
 		pathParameters["itemId"] = itemId
@@ -761,7 +766,8 @@ public class VideosApi(
 		queryParameters["videoStreamIndex"] = videoStreamIndex
 		queryParameters["context"] = context
 		queryParameters["streamOptions"] = streamOptions
-		return api.createUrl("/Videos/{itemId}/stream", pathParameters, queryParameters)
+		return api.createUrl("/Videos/{itemId}/stream", pathParameters, queryParameters,
+				includeCredentials)
 	}
 
 	/**

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/ApiClient.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/ApiClient.kt
@@ -14,12 +14,16 @@ public interface ApiClient {
 
 	/**
 	 * Create a complete url based on the [baseUrl] and given parameters.
-	 * Uses [createPath] to create the path
+	 * Uses [createPath] to create the path.
+	 *
+	 * When [includeCredentials] is true it will add the access token to the
+	 * url to make an authenticated request.
 	 */
 	public fun createUrl(
 		pathTemplate: String,
 		pathParameters: Map<String, Any?> = emptyMap(),
 		queryParameters: Map<String, Any?> = emptyMap(),
+		includeCredentials: Boolean = false
 	): String
 
 	public fun createAuthorizationHeader(): String?

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/KtorClient.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/apiclient/api/client/KtorClient.kt
@@ -72,6 +72,7 @@ public open class KtorClient(
 		pathTemplate: String,
 		pathParameters: Map<String, Any?>,
 		queryParameters: Map<String, Any?>,
+		includeCredentials: Boolean
 	): String {
 		// Check if the base url is not null
 		val baseUrl = checkNotNull(baseUrl)
@@ -91,6 +92,9 @@ public open class KtorClient(
 				.forEach {
 					parameters.append(it.key, it.value.toString())
 				}
+
+			if (includeCredentials)
+				parameters.append("ApiKey", checkNotNull(accessToken))
 		}.buildString()
 	}
 

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
@@ -53,13 +53,18 @@ class OperationUrlBuilder(
 			.union(data.queryParameters)
 			.forEach { parameter -> addParameter(buildParameter(parameter)) }
 
+		ParameterSpec.builder("includeCredentials", Boolean::class).apply {
+			defaultValue("%L", "false")
+			addKdoc("%L", Strings.INCLUDE_CREDENTIALS_DESCRIPTION)
+		}.build().let(::addParameter)
+
 		// Create parameter maps
 		addParameterMapStatements("pathParameters", data.pathParameters)
 		addParameterMapStatements("queryParameters", data.queryParameters)
 
 		// Call API
 		addStatement(
-			"return·api.createUrl(%S, pathParameters, queryParameters)",
+			"return·api.createUrl(%S, pathParameters, queryParameters, includeCredentials)",
 			data.pathTemplate
 		)
 	}.build()

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Strings.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Strings.kt
@@ -26,4 +26,9 @@ object Strings {
 	 * The default service name for API operations
 	 */
 	const val DEFAULT_API_SERVICE = "Misc"
+
+	/**
+	 * The description used for the "includeCredentials" parameter in API URL functions
+	 */
+	const val INCLUDE_CREDENTIALS_DESCRIPTION = "Add the access token to the url to make an authenticated request."
 }


### PR DESCRIPTION
This will help when we request a URL for an image to load it with Glide but the image endpoint is authenticated.

As always: first commit is the actual change, the second updates the generated code.