### PR TITLE
Set default value for requireAuthentication

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 
 [*]
 insert_final_newline = true
+end_of_line = lf
 
 [{*.kts, *.kt}]
 charset = utf-8

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
@@ -54,7 +54,7 @@ class OperationUrlBuilder(
 			.forEach { parameter -> addParameter(buildParameter(parameter)) }
 
 		ParameterSpec.builder("includeCredentials", Boolean::class).apply {
-			defaultValue("%L", "false")
+			defaultValue("%L", data.requireAuthentication)
 			addKdoc("%L", Strings.INCLUDE_CREDENTIALS_DESCRIPTION)
 		}.build().let(::addParameter)
 

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
@@ -75,8 +75,8 @@ class OpenApiApiServicesBuilder(
 					println("Missing return-type for operation $operationName (status-codes: ${operation.responses.keys})")
 
 				val requireAuthentication = operation.security
-					?.mapNotNull { it[Security.SECURITY_SCHEME] }
-					?.firstOrNull()
+					?.firstOrNull { requirement -> requirement.containsKey(Security.SECURITY_SCHEME) }
+					?.get(Security.SECURITY_SCHEME)
 					?.any(Security.AUTHENTICATION_POLICIES::contains)
 					?: false
 

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
@@ -8,6 +8,7 @@ import net.pearx.kasechange.toCamelCase
 import org.jellyfin.openapi.builder.Builder
 import org.jellyfin.openapi.builder.api.ApiNameBuilder
 import org.jellyfin.openapi.constants.MimeType
+import org.jellyfin.openapi.constants.Security
 import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.hooks.ApiTypePath
 import org.jellyfin.openapi.model.ApiService
@@ -73,12 +74,19 @@ class OpenApiApiServicesBuilder(
 				if (returnType == Unit::class.asTypeName() && "200" in operation.responses)
 					println("Missing return-type for operation $operationName (status-codes: ${operation.responses.keys})")
 
+				val requireAuthentication = operation.security
+					?.mapNotNull { it[Security.SECURITY_SCHEME] }
+					?.firstOrNull()
+					?.any(Security.AUTHENTICATION_POLICIES::contains)
+					?: false
+
 				operations[serviceName]!! += ApiServiceOperation(
 					name = operationName,
 					description = operation.description ?: operation.summary,
 					deprecated = operation.deprecated == true,
 					pathTemplate = path,
 					method = method,
+					requireAuthentication = requireAuthentication,
 					returnType = returnType,
 					pathParameters = pathParameters,
 					queryParameters = queryParameters,

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Security.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Security.kt
@@ -1,0 +1,6 @@
+package org.jellyfin.openapi.constants
+
+object Security {
+	const val SECURITY_SCHEME = "CustomAuthentication"
+	val AUTHENTICATION_POLICIES = arrayOf("DefaultAuthorization", "RequiresElevation")
+}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ApiServiceOperation.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ApiServiceOperation.kt
@@ -8,6 +8,7 @@ data class ApiServiceOperation(
 	val deprecated: Boolean,
 	val pathTemplate: String,
 	val method: HttpMethod,
+	val requireAuthentication: Boolean,
 	val returnType: TypeName,
 	val pathParameters: Collection<ApiServiceOperationParameter> = emptyList(),
 	val queryParameters: Collection<ApiServiceOperationParameter> = emptyList(),


### PR DESCRIPTION
OpenAPI spec from server now includes security metadata for all operations so we can determine the default value for this parameter now. Tested it with the latest openapi spec and it worked as expected.

Will update the spec (again) later when 10.7.0-rc.1 is released. 