### PR TITLE
Expose ktor-http library

### DIFF
--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 	implementation(Dependencies.KotlinX.coroutinesCore)
 	implementation(Dependencies.KotlinX.serializationJson)
 
-	implementation(Dependencies.Ktor.http)
+	api(Dependencies.Ktor.http)
 
 	// Logging
 	implementation(Dependencies.Slf4j.api)


### PR DESCRIPTION
To use the ByteReadChannel there's a lot of extension functions. Unfortunately those weren't exposed and I couldn't `.copyTo(outputStream)` making it quite useless.

Exposing the ktor-http package fixes this.


https://api.ktor.io/1.4.0/io.ktor.utils.io/-byte-read-channel/index.html