### PR TITLE
Fix server discovery not ignoring unknown keys

### DIFF
--- a/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/LocalServerDiscovery.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/apiclient/discovery/LocalServerDiscovery.kt
@@ -32,6 +32,9 @@ public class LocalServerDiscovery(
 	}
 
 	private val logger = LoggerFactory.getLogger("LocalServerDiscovery")
+	private val json = Json {
+		ignoreUnknownKeys = true
+	}
 
 	/**
 	 * Send our broadcast message to a given address
@@ -63,7 +66,7 @@ public class LocalServerDiscovery(
 			logger.debug("""Received message "$message"""")
 
 			// Read as JSON
-			val info = Json.decodeFromString(DiscoveryServerInfo.serializer(), message)
+			val info = json.decodeFromString(DiscoveryServerInfo.serializer(), message)
 
 			info
 		} catch (err: SocketTimeoutException) {


### PR DESCRIPTION
Found this while I tried debugging an issue on the 0.7 branch. We don't read the value of EndpointAddress but the serializer really wanted to read it.