### PR TITLE
Fix uuid parser sometimes failing

### DIFF
--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/serializer/UUIDSerializer.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/serializer/UUIDSerializer.kt
@@ -17,8 +17,7 @@ public class UUIDSerializer : KSerializer<UUID> {
 	override fun deserialize(decoder: Decoder): UUID {
 		val uuid = decoder.decodeString()
 
-		return if (uuid.length == 32) UUID.fromString(uuid.replace(UUID_REGEX, "$1-$2-$3-$4-$5"))
-		else UUID.fromString(uuid)
+		return UUID.fromString(uuid.replace(UUID_REGEX, "$1-$2-$3-$4-$5"))
 	}
 
 	override fun serialize(encoder: Encoder, value: UUID) {
@@ -26,6 +25,6 @@ public class UUIDSerializer : KSerializer<UUID> {
 	}
 
 	private companion object {
-		private val UUID_REGEX = "^([a-z\\d]{8})([a-z\\d]{4})(4[a-z\\d]{3})([a-z\\d]{4})([a-z\\d]{12})\$".toRegex()
+		private val UUID_REGEX = "^([a-z\\d]{8})([a-z\\d]{4})([a-z\\d]{4})([a-z\\d]{4})([a-z\\d]{12})\$".toRegex()
 	}
 }

--- a/jellyfin-model/src/test/kotlin/org/jellyfin/apiclient/model/serializer/UUIDSerializerTests.kt
+++ b/jellyfin-model/src/test/kotlin/org/jellyfin/apiclient/model/serializer/UUIDSerializerTests.kt
@@ -32,5 +32,13 @@ public class UUIDSerializerTests {
 			UUID.fromString("713dc3fe-952b-438f-a70e-d35e4ef0525a"),
 			Json.decodeFromString(instance, "\"713dc3fe952b438fa70ed35e4ef0525a\"")
 		)
+		assertEquals(
+			UUID.fromString("be275f0b-db14-71d8-6d2d-be5b8bb6918e"),
+			Json.decodeFromString(instance, "\"be275f0bdb1471d86d2dbe5b8bb6918e\"")
+		)
+		assertEquals(
+			UUID.fromString("70a37b76-f996-24a5-7725-cbf8345e2b62"),
+			Json.decodeFromString(instance, "\"70a37b76f99624a57725cbf8345e2b62\"")
+		)
 	}
 }


### PR DESCRIPTION
- Fixed the regex (apparently we stopped using UUIDv4 at some point after 10.7RC1)
- Simplified deserialize function
- Added 2 additional test strings