### PR TITLE
Update OpenAPI specification to 10.7~RC3

### DIFF
--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MediaInfoApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MediaInfoApi.kt
@@ -9,6 +9,7 @@ import io.ktor.utils.io.ByteReadChannel
 import java.util.UUID
 import kotlin.Any
 import kotlin.Boolean
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.String
@@ -43,6 +44,24 @@ public class MediaInfoApi(
 	/**
 	 * For backwards compatibility parameters can be sent via Query or Body, with Query having higher
 	 * precedence.
+	 * Query parameters are obsolete.
+	 *
+	 * @param itemId The item id.
+	 */
+	public suspend fun getPostedPlaybackInfo(itemId: UUID, `data`: PlaybackInfoDto):
+			Response<PlaybackInfoResponse> {
+		val pathParameters = mutableMapOf<String, Any?>()
+		pathParameters["itemId"] = itemId
+		val queryParameters = emptyMap<String, Any?>()
+		val response = api.post<PlaybackInfoResponse>("/Items/{itemId}/PlaybackInfo", pathParameters,
+				queryParameters, data)
+		return response
+	}
+
+	/**
+	 * For backwards compatibility parameters can be sent via Query or Body, with Query having higher
+	 * precedence.
+	 * Query parameters are obsolete.
 	 *
 	 * @param itemId The item id.
 	 * @param userId The user id.
@@ -60,7 +79,8 @@ public class MediaInfoApi(
 	 * @param allowVideoStreamCopy Whether to allow to copy the video stream. Default: true.
 	 * @param allowAudioStreamCopy Whether to allow to copy the audio stream. Default: true.
 	 */
-	public suspend fun getPostedPlaybackInfo(
+	@Deprecated("This member is deprecated and may be removed in the future")
+	public suspend fun getPostedPlaybackInfoDeprecated(
 		itemId: UUID,
 		userId: UUID? = null,
 		maxStreamingBitrate: Int? = null,

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/PlaylistsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/PlaylistsApi.kt
@@ -8,6 +8,7 @@ package org.jellyfin.apiclient.api.operations
 import java.util.UUID
 import kotlin.Any
 import kotlin.Boolean
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.String
 import kotlin.Unit
@@ -26,13 +27,28 @@ public class PlaylistsApi(
 	/**
 	 * For backwards compatibility parameters can be sent via Query or Body, with Query having higher
 	 * precedence.
+	 * Query parameters are obsolete.
+	 */
+	public suspend fun createPlaylist(`data`: CreatePlaylistDto): Response<PlaylistCreationResult> {
+		val pathParameters = emptyMap<String, Any?>()
+		val queryParameters = emptyMap<String, Any?>()
+		val response = api.post<PlaylistCreationResult>("/Playlists", pathParameters, queryParameters,
+				data)
+		return response
+	}
+
+	/**
+	 * For backwards compatibility parameters can be sent via Query or Body, with Query having higher
+	 * precedence.
+	 * Query parameters are obsolete.
 	 *
 	 * @param name The playlist name.
 	 * @param ids The item ids.
 	 * @param userId The user id.
 	 * @param mediaType The media type.
 	 */
-	public suspend fun createPlaylist(
+	@Deprecated("This member is deprecated and may be removed in the future")
+	public suspend fun createPlaylistDeprecated(
 		name: String? = null,
 		ids: List<UUID>? = emptyList(),
 		userId: UUID? = null,

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/TvShowsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/TvShowsApi.kt
@@ -148,6 +148,7 @@ public class TvShowsApi(
 	 * @param enableImageTypes Optional. The image types to include in the output.
 	 * @param enableUserData Optional. Include user data.
 	 * @param enableTotalRecordCount Whether to enable the total records count. Defaults to true.
+	 * @param disableFirstEpisode Whether to disable sending the first episode in a series as next up.
 	 */
 	public suspend fun getNextUp(
 		userId: UUID? = null,
@@ -160,7 +161,8 @@ public class TvShowsApi(
 		imageTypeLimit: Int? = null,
 		enableImageTypes: List<ImageType>? = emptyList(),
 		enableUserData: Boolean? = null,
-		enableTotalRecordCount: Boolean = true
+		enableTotalRecordCount: Boolean = true,
+		disableFirstEpisode: Boolean = false
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
@@ -175,6 +177,7 @@ public class TvShowsApi(
 		queryParameters["enableImageTypes"] = enableImageTypes
 		queryParameters["enableUserData"] = enableUserData
 		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
+		queryParameters["disableFirstEpisode"] = disableFirstEpisode
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Shows/NextUp", pathParameters, queryParameters,
 				data)

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/ApiBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/ApiBuilder.kt
@@ -4,6 +4,7 @@ import com.squareup.kotlinpoet.*
 import org.jellyfin.openapi.builder.Builder
 import org.jellyfin.openapi.constants.Classes
 import org.jellyfin.openapi.constants.Packages
+import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.hooks.OperationUrlHook
 import org.jellyfin.openapi.model.ApiService
 import org.jellyfin.openapi.model.JellyFile
@@ -19,8 +20,28 @@ class ApiBuilder(
 		addProperty(PropertySpec.builder("api", apiClientType, KModifier.PRIVATE).initializer("api").build())
 		primaryConstructor(FunSpec.constructorBuilder().addParameter("api", apiClientType).build())
 
+		// Handle deprecated members
+		val operations = data.operations.map { namedOperation ->
+			// Check if any member is deprecated
+			if (namedOperation.queryParameters.any { it.deprecated }) {
+				// Return 2 operations, one with and one without deprecated members
+				listOf(
+					// Remove deprecated parameters from normal function
+					namedOperation.copy(
+						queryParameters = namedOperation.queryParameters.filterNot { it.deprecated }
+					),
+					// Add new "deprecated" function with old parameters
+					namedOperation.copy(
+						name = namedOperation.name + Strings.DEPRECATED_OPERATION_SUFFIX,
+						// Mark the operation as deprecated
+						deprecated = true
+					)
+				)
+			} else listOf(namedOperation)
+		}.flatten()
+
 		// Add operations
-		data.operations.forEach { namedOperation ->
+		operations.forEach { namedOperation ->
 			addFunction(operationBuilder.build(namedOperation))
 
 			if (operationUrlHooks.any { it.shouldOperationBuildUrlFun(data, namedOperation) })

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
@@ -50,9 +50,6 @@ class OperationBuilder(
 
 		// Add description
 		data.description?.let { addKdoc("%L", it) }
-
-		// Add deprecated annotation
-		if (data.deprecated) addAnnotation(deprecatedAnnotationSpecBuilder.build(Strings.DEPRECATED_MEMBER))
 	}.build()
 
 

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
@@ -11,7 +11,7 @@ import org.jellyfin.openapi.model.ApiServiceOperationParameter
 class OperationUrlBuilder(
 	private val deprecatedAnnotationSpecBuilder: DeprecatedAnnotationSpecBuilder
 ) : Builder<ApiServiceOperation, FunSpec> {
-	private fun buildFunctionShell(data: ApiServiceOperation) = FunSpec.builder(data.name + "Url").apply {
+	private fun buildFunctionShell(data: ApiServiceOperation) = FunSpec.builder(data.name  + Strings.URL_OPERATION_SUFFIX).apply {
 		// Add description
 		data.description?.let { addKdoc("%L", it) }
 
@@ -28,9 +28,6 @@ class OperationUrlBuilder(
 
 		// Add description
 		data.description?.let { addKdoc("%L", it) }
-
-		// Add deprecated annotation
-		if (data.deprecated) addAnnotation(deprecatedAnnotationSpecBuilder.build(Strings.DEPRECATED_MEMBER))
 	}.build()
 
 

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Strings.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Strings.kt
@@ -31,4 +31,14 @@ object Strings {
 	 * The description used for the "includeCredentials" parameter in API URL functions
 	 */
 	const val INCLUDE_CREDENTIALS_DESCRIPTION = "Add the access token to the url to make an authenticated request."
+
+	/**
+	 * The suffix added to the name of a deprecated operation.
+	 */
+	const val DEPRECATED_OPERATION_SUFFIX = "Deprecated"
+
+	/**
+	 * The suffix added to the name of a URL operation. Added after [URL_OPERATION_SUFFIX].
+	 */
+	const val URL_OPERATION_SUFFIX = "Url"
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb6f75af7066e6a5808c703a6b42e4f5d9ce5dfaf61fe8dfb38b170d29ae17f4
-size 1757700
+oid sha256:a5e57d7f400c781689a8e2ed5e968c6fe3f8f4c5474865943ca3a0bb9cf99f07
+size 1759029


### PR DESCRIPTION
- Change behavior for deprecated parameters in API operations to generate a secondary function

  The @deprecated annotation is not supported by Kotlin (although IntelliJ worked fine with it!). The new behavior will generate one function with the deprecated members removed and another one with them added. The latter will have a "Deprecated" suffix in the name and a @deprecated annotation on the function.
- Update OpenAPI specification to 10.7~RC3

The changes between RC2-RC3 are small so you can see the new behavior perfectly fine. I didn't notice that the old approach didn't work because this is the first release that adds deprecated parameters.