### PR TITLE
Add String.toUUID and String.toUUIDOrNull functions

### DIFF
--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/serializer/UUIDSerializer.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/serializer/UUIDSerializer.kt
@@ -8,6 +8,23 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import java.util.*
 
+private val UUID_REGEX = "^([a-z\\d]{8})([a-z\\d]{4})([a-z\\d]{4})([a-z\\d]{4})([a-z\\d]{12})\$".toRegex()
+
+/**
+ * Convert string to UUID. Accepts simple and hyphenated notations.
+ */
+public fun String.toUUID(): UUID = UUID.fromString(replace(UUID_REGEX, "$1-$2-$3-$4-$5"))
+
+/**
+ * Convert string to UUID or null if the string is not a uuid.
+ * Accepts simple and hyphenated notations.
+ */
+public fun String.toUUIDOrNull(): UUID? = try {
+	toUUID()
+} catch (err: IllegalArgumentException) {
+	null
+}
+
 /**
  * A UUID serializer that supports the GUIDs without dashes from the Jellyfin API
  */
@@ -15,16 +32,10 @@ public class UUIDSerializer : KSerializer<UUID> {
 	override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
 
 	override fun deserialize(decoder: Decoder): UUID {
-		val uuid = decoder.decodeString()
-
-		return UUID.fromString(uuid.replace(UUID_REGEX, "$1-$2-$3-$4-$5"))
+		return decoder.decodeString().toUUID()
 	}
 
 	override fun serialize(encoder: Encoder, value: UUID) {
 		encoder.encodeString(value.toString())
-	}
-
-	private companion object {
-		private val UUID_REGEX = "^([a-z\\d]{8})([a-z\\d]{4})([a-z\\d]{4})([a-z\\d]{4})([a-z\\d]{12})\$".toRegex()
 	}
 }

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/serializer/UUIDSerializer.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/apiclient/model/serializer/UUIDSerializer.kt
@@ -12,11 +12,12 @@ private val UUID_REGEX = "^([a-z\\d]{8})([a-z\\d]{4})([a-z\\d]{4})([a-z\\d]{4})(
 
 /**
  * Convert string to UUID. Accepts simple and hyphenated notations.
+ * @throws IllegalArgumentException if string is not a valid UUID.
  */
 public fun String.toUUID(): UUID = UUID.fromString(replace(UUID_REGEX, "$1-$2-$3-$4-$5"))
 
 /**
- * Convert string to UUID or null if the string is not a uuid.
+ * Convert string to UUID or null if the string is not an UUID.
  * Accepts simple and hyphenated notations.
  */
 public fun String.toUUIDOrNull(): UUID? = try {
@@ -26,7 +27,7 @@ public fun String.toUUIDOrNull(): UUID? = try {
 }
 
 /**
- * A UUID serializer that supports the GUIDs without dashes from the Jellyfin API
+ * A UUID serializer that supports the GUIDs without dashes from the Jellyfin API.
  */
 public class UUIDSerializer : KSerializer<UUID> {
 	override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)


### PR DESCRIPTION
jellyfin-android needs to parse UUID's passed from the webclient. The `UUID.parseString` function in Java only allows hyphenated strings so we need to expose the apiclient UUID parser to parse the simple notation.

This PR adds two new extension functions to the String class to parse UUID's. The serializer now uses those functions to prevent duplicate code.