### PR TITLE
Add setDevice method

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
 	}
 
 	dependencies {
-		classpath("com.android.tools.build:gradle:4.0.1")
+		classpath("com.android.tools.build:gradle:4.1.1")
 		classpath(kotlin("gradle-plugin", "1.3.72"))
 	}
 }

--- a/library/src/main/java/org/jellyfin/apiclient/interaction/BaseApiClient.java
+++ b/library/src/main/java/org/jellyfin/apiclient/interaction/BaseApiClient.java
@@ -152,6 +152,10 @@ public abstract class BaseApiClient
 	}
 
     private IDevice device;
+	public final void setDevice(IDevice value)
+	{
+		device = value;
+	}
     public final IDevice getDevice()
     {
         return device;


### PR DESCRIPTION
Needed for authentication rewrite in jellyfin-androidtv. Note that `SetAuthenticationInfo` should be called after to reset the HTTP header values.

# Note: Targets release branch