### PR TITLE
Add merge conflict labeler and gradle update and validate tasks

### DIFF
--- a/.github/workflows/gradlew-update.yaml
+++ b/.github/workflows/gradlew-update.yaml
@@ -1,0 +1,17 @@
+name: Gradle
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+
+jobs:
+  update:
+    runs-on: ubuntu-20.04
+    if: github.repository == 'jellyfin/jellyfin-apiclient-java'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Validate Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradlew-validate.yaml
+++ b/.github/workflows/gradlew-validate.yaml
@@ -1,0 +1,18 @@
+name: Gradle
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '**/gradlе-wrapper.jar'
+
+jobs:
+  validate:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/merge-conflict-labeler.yaml
+++ b/.github/workflows/merge-conflict-labeler.yaml
@@ -1,0 +1,15 @@
+name: Merge conflicts labeler
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  push:
+jobs:
+  triage:
+    runs-on: ubuntu-20.04
+    if: github.repository == 'jellyfin/jellyfin-apiclient-java'
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@v2.0
+        with:
+          CONFLICT_LABEL_NAME: merge conflict
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Part of this comes from #163 with some slight improvements, the labeler comes from the ATV repo with some changes (added a schedule).

