### PR TITLE
Rename gradle wrapper workflows

### DIFF
--- a/.github/workflows/gradlew-update.yaml
+++ b/.github/workflows/gradlew-update.yaml
@@ -1,4 +1,4 @@
-name: Gradle
+name: Gradle update
 
 on:
   schedule:

--- a/.github/workflows/gradlew-validate.yaml
+++ b/.github/workflows/gradlew-validate.yaml
@@ -1,4 +1,4 @@
-name: Gradle
+name: Gradle validate
 
 on:
   push:


### PR DESCRIPTION
Apparently two workflows with the same name is confusing