### PR TITLE
Use OperationBuilder as parent class in OperationUrlBuilder and remove duplicate code

### DIFF
--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/AudioApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/AudioApi.kt
@@ -316,7 +316,7 @@ public class AudioApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext? = null,
-		streamOptions: Map<String, String>? = null,
+		streamOptions: Map<String, String>? = emptyMap(),
 		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
@@ -668,7 +668,7 @@ public class AudioApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext? = null,
-		streamOptions: Map<String, String>? = null,
+		streamOptions: Map<String, String>? = emptyMap(),
 		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/DynamicHlsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/DynamicHlsApi.kt
@@ -334,7 +334,7 @@ public class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null,
+		streamOptions: Map<String, String>? = emptyMap(),
 		includeCredentials: Boolean = true
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
@@ -689,7 +689,7 @@ public class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null,
+		streamOptions: Map<String, String>? = emptyMap(),
 		includeCredentials: Boolean = true
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
@@ -1045,8 +1045,8 @@ public class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null,
-		enableAdaptiveBitrateStreaming: Boolean,
+		streamOptions: Map<String, String>? = emptyMap(),
+		enableAdaptiveBitrateStreaming: Boolean = true,
 		includeCredentials: Boolean = true
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
@@ -1412,7 +1412,7 @@ public class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null,
+		streamOptions: Map<String, String>? = emptyMap(),
 		includeCredentials: Boolean = true
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
@@ -1761,7 +1761,7 @@ public class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null,
+		streamOptions: Map<String, String>? = emptyMap(),
 		includeCredentials: Boolean = true
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
@@ -2111,8 +2111,8 @@ public class DynamicHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null,
-		enableAdaptiveBitrateStreaming: Boolean,
+		streamOptions: Map<String, String>? = emptyMap(),
+		enableAdaptiveBitrateStreaming: Boolean = true,
 		includeCredentials: Boolean = true
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MediaInfoApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/MediaInfoApi.kt
@@ -202,7 +202,7 @@ public class MediaInfoApi(
 	 * @param size The bitrate. Defaults to 102400.
 	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
-	public fun getBitrateTestBytesUrl(size: Int, includeCredentials: Boolean = true): String {
+	public fun getBitrateTestBytesUrl(size: Int = 102400, includeCredentials: Boolean = true): String {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = mutableMapOf<String, Any?>()
 		queryParameters["size"] = size

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/UniversalAudioApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/UniversalAudioApi.kt
@@ -116,7 +116,7 @@ public class UniversalAudioApi(
 	 */
 	public fun getUniversalAudioStreamUrl(
 		itemId: UUID,
-		container: List<String>? = null,
+		container: List<String>? = emptyList(),
 		mediaSourceId: String? = null,
 		deviceId: String? = null,
 		userId: UUID? = null,
@@ -132,7 +132,7 @@ public class UniversalAudioApi(
 		maxAudioBitDepth: Int? = null,
 		enableRemoteMedia: Boolean? = null,
 		breakOnNonKeyFrames: Boolean,
-		enableRedirection: Boolean,
+		enableRedirection: Boolean = true,
 		includeCredentials: Boolean = true
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideoHlsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideoHlsApi.kt
@@ -328,7 +328,7 @@ public class VideoHlsApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null,
+		streamOptions: Map<String, String>? = emptyMap(),
 		maxWidth: Int? = null,
 		maxHeight: Int? = null,
 		enableSubtitlesInManifest: Boolean? = null,

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideosApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/apiclient/api/operations/VideosApi.kt
@@ -324,7 +324,7 @@ public class VideosApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null,
+		streamOptions: Map<String, String>? = emptyMap(),
 		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()
@@ -712,7 +712,7 @@ public class VideosApi(
 		audioStreamIndex: Int? = null,
 		videoStreamIndex: Int? = null,
 		context: EncodingContext,
-		streamOptions: Map<String, String>? = null,
+		streamOptions: Map<String, String>? = emptyMap(),
 		includeCredentials: Boolean = false
 	): String {
 		val pathParameters = mutableMapOf<String, Any?>()

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
@@ -10,10 +10,10 @@ import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.model.ApiServiceOperation
 import org.jellyfin.openapi.model.ApiServiceOperationParameter
 
-class OperationBuilder(
+open class OperationBuilder(
 	private val deprecatedAnnotationSpecBuilder: DeprecatedAnnotationSpecBuilder
 ) : Builder<ApiServiceOperation, FunSpec> {
-	private fun buildFunctionShell(data: ApiServiceOperation) = FunSpec.builder(data.name).apply {
+	protected open fun buildFunctionShell(data: ApiServiceOperation) = FunSpec.builder(data.name).apply {
 		// Make function suspended
 		addModifiers(KModifier.SUSPEND)
 
@@ -27,7 +27,7 @@ class OperationBuilder(
 		returns(ClassName(Packages.API_CLIENT, Classes.API_RESPONSE).plusParameter(data.returnType))
 	}
 
-	private fun buildParameter(data: ApiServiceOperationParameter) = ParameterSpec.builder(data.name, data.type).apply {
+	protected fun buildParameter(data: ApiServiceOperationParameter) = ParameterSpec.builder(data.name, data.type).apply {
 		// Determine class name without parameters
 		val typeClassName = when (data.type) {
 			is ClassName -> data.type
@@ -53,7 +53,7 @@ class OperationBuilder(
 	}.build()
 
 
-	private fun FunSpec.Builder.addParameterMapStatements(name: String, parameters: Collection<ApiServiceOperationParameter>) {
+	protected fun FunSpec.Builder.addParameterMapStatements(name: String, parameters: Collection<ApiServiceOperationParameter>) {
 		// Create map
 		// val $(name) = $("emptyMap"|"mutableMapOf")<String, Any?>()
 		val mapType = if (parameters.isEmpty()) "emptyMap" else "mutableMapOf"

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
@@ -2,16 +2,14 @@ package org.jellyfin.openapi.builder.api
 
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.ParameterSpec
-import org.jellyfin.openapi.builder.Builder
 import org.jellyfin.openapi.builder.extra.DeprecatedAnnotationSpecBuilder
 import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.model.ApiServiceOperation
-import org.jellyfin.openapi.model.ApiServiceOperationParameter
 
 class OperationUrlBuilder(
 	private val deprecatedAnnotationSpecBuilder: DeprecatedAnnotationSpecBuilder
-) : Builder<ApiServiceOperation, FunSpec> {
-	private fun buildFunctionShell(data: ApiServiceOperation) = FunSpec.builder(data.name  + Strings.URL_OPERATION_SUFFIX).apply {
+) : OperationBuilder(deprecatedAnnotationSpecBuilder) {
+	override fun buildFunctionShell(data: ApiServiceOperation) = FunSpec.builder(data.name  + Strings.URL_OPERATION_SUFFIX).apply {
 		// Add description
 		data.description?.let { addKdoc("%L", it) }
 
@@ -20,28 +18,6 @@ class OperationUrlBuilder(
 
 		// Set return type
 		returns(String::class)
-	}
-
-	private fun buildParameter(data: ApiServiceOperationParameter) = ParameterSpec.builder(data.name, data.type).apply {
-		// Set value to null by default for nullable values
-		if (data.type.isNullable) defaultValue("%L", "null")
-
-		// Add description
-		data.description?.let { addKdoc("%L", it) }
-	}.build()
-
-
-	private fun FunSpec.Builder.addParameterMapStatements(name: String, parameters: Collection<ApiServiceOperationParameter>) {
-		// Create map
-		// val $(name) = $("emptyMap"|"mutableMapOf")<String, Any?>()
-		val mapType = if (parameters.isEmpty()) "emptyMap" else "mutableMapOf"
-		addStatement("val %N = %N<%T, %T?>()", name, mapType, String::class, Any::class)
-
-		// Add parameters
-		parameters.forEach { parameter ->
-			// $(name)[$(parameter.originalName)] = parameter.name
-			addStatement("%L[%S] = %N", name, parameter.originalName, parameter.name)
-		}
 	}
 
 	override fun build(data: ApiServiceOperation): FunSpec = buildFunctionShell(data).apply {


### PR DESCRIPTION
Fixes a different implementation for the buildParameter function.

The Url functions now support default values too :)