### PR TITLE
Move build and testing CI to GitHub Actions

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -3,10 +3,6 @@ variables:
 
 trigger:
   batch: true
-  branches:
-    include:
-      - master
-      - release*
   tags:
     include:
       - '*'
@@ -17,41 +13,6 @@ pr:
       - '*'
 
 jobs:
-  - job: Test
-    displayName: 'Test'
-
-    pool:
-      vmImage: 'ubuntu-latest'
-
-    steps:
-      - task: Gradle@2
-        displayName: 'Run Tests'
-        inputs:
-          gradleWrapperFile: 'gradlew'
-          tasks: 'test'
-          publishJUnitResults: true
-          testResultsFiles: '**/TEST-*.xml'
-          javaHomeOption: 'JDKVersion'
-          jdkVersionOption: 1.11
-          sonarQubeRunAnalysis: false
-
-  - job: Build
-    displayName: 'Build'
-
-    pool:
-      vmImage: 'ubuntu-latest'
-
-    steps:
-      - task: Gradle@2
-        displayName: 'Build'
-        inputs:
-          gradleWrapperFile: 'gradlew'
-          tasks: 'distZip'
-          publishJUnitResults: false
-          testResultsFiles: '**/TEST-*.xml'
-          javaHomeOption: 'JDKVersion'
-          jdkVersionOption: 1.11
-          sonarQubeRunAnalysis: false
 
   - job: Publish
     displayName: 'Publish'

--- a/.github/workflows/apiclient-test.yaml
+++ b/.github/workflows/apiclient-test.yaml
@@ -1,0 +1,35 @@
+name: Apiclient Test
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [8, 11, 15]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Setup Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-java-${{ matrix.java }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-java-${{ matrix.java }}-gradle-
+            ${{ runner.os }}-java-
+      - name: Run test task
+        run: ./gradlew --build-cache --no-daemon --info test


### PR DESCRIPTION
- Add new workflow "apiclient-test"
  - this runs the test task which will build and test all modules
- Remove test and build jobs from azure
  - Also changed the triggers to only run on tags now so the azure file is correct
  - 1.0.0 will not use azure for publishing though

The CI file is largely copied from #163 but with changes in the caching keys