### PR TITLE
Move publishing CI to GitHub actions

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -7,11 +7,6 @@ trigger:
     include:
       - '*'
 
-pr:
-  branches:
-    include:
-      - '*'
-
 jobs:
 
   - job: Publish
@@ -31,7 +26,7 @@ jobs:
         displayName: 'Build, Distribute & Publish'
         inputs:
           gradleWrapperFile: 'gradlew'
-          tasks: 'publish distZip'
+          tasks: 'distZip'
           publishJUnitResults: false
           testResultsFiles: '**/TEST-*.xml'
           javaHomeOption: 'JDKVersion'

--- a/.github/workflows/apiclient-publish.yaml
+++ b/.github/workflows/apiclient-publish.yaml
@@ -1,0 +1,29 @@
+name: Apiclient Publish
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    environment: release
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Set JELLYFIN_VERSION
+        if: ${{ startsWith(github.ref, 'refs/tags') }}
+        run: echo "JELLYFIN_VERSION=$(echo ${GITHUB_REF#refs/tags/} | tr / -)" >> $GITHUB_ENV
+      - name: Run publish task
+        run: ./gradlew --no-daemon --info publish
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,14 +23,14 @@ nexusPublishing.repositories.sonatype {
 	nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
 	snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
 
-	username.set(project.properties["ossrh.username"].toString())
-	password.set(project.properties["ossrh.password"].toString())
+	username.set(getProperty("ossrh.username"))
+	password.set(getProperty("ossrh.password"))
 }
 
 subprojects {
 	// Enable required plugins
-	apply<MavenPublishPlugin>()
 	apply<SigningPlugin>()
+	apply<MavenPublishPlugin>()
 	apply<io.gitlab.arturbosch.detekt.DetektPlugin>()
 
 	// Add dependency repositories
@@ -40,8 +40,8 @@ subprojects {
 	afterEvaluate {
 		// Add signing config
 		configure<SigningExtension> {
-			val signingKey = project.properties["signing.key"]?.toString()
-			val signingPassword = project.properties["signing.password"]?.toString()
+			val signingKey = getProperty("signing.key")
+			val signingPassword = getProperty("signing.password") ?: ""
 
 			if (signingKey != null) {
 				useInMemoryPgpKeys(signingKey, signingPassword)

--- a/buildSrc/src/main/kotlin/Pom.kt
+++ b/buildSrc/src/main/kotlin/Pom.kt
@@ -1,14 +1,14 @@
 import org.gradle.api.publish.maven.MavenPublication
 
 fun MavenPublication.defaultPom() = pom {
-	name.set("jellyfin-apiclient-java")
+	name.set("${groupId}:${artifactId}")
 	description.set("Kotlin API Client for Jellyfin")
 	url.set("https://github.com/jellyfin/jellyfin-apiclient-java")
 
 	scm {
-		url.set("https://github.com/jellyfin/jellyfin-apiclient-java")
-		connection.set("scm:git:git@github.com:jellyfin/jellyfin-apiclient-java.git")
-		developerConnection.set("scm:git:git@github.com/jellyfin/jellyfin-apiclient-java.git")
+		connection.set("scm:git:git://github.com/jellyfin/jellyfin-apiclient-java.git")
+		developerConnection.set("scm:git:ssh://github.com:jellyfin/jellyfin-apiclient-java.git")
+		url.set("https://github.com/jellyfin/jellyfin-apiclient-java/tree/master")
 	}
 
 	licenses {
@@ -23,6 +23,8 @@ fun MavenPublication.defaultPom() = pom {
 			id.set("nielsvanvelzen")
 			name.set("Niels van Velzen")
 			url.set("https://github.com/nielsvanvelzen")
+			organization.set("Jellyfin")
+			organizationUrl.set("https://jellyfin.org")
 		}
 	}
 }

--- a/buildSrc/src/main/kotlin/Properties.kt
+++ b/buildSrc/src/main/kotlin/Properties.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 fun Project.getProperty(name: String): String? {
 	// sample.var --> SAMPLE_VAR
 	val environmentName = name.toUpperCase().replace(".", "_")
-
-	return findProperty(name)?.toString() ?: System.getenv(environmentName) ?: null
+	val value = findProperty(name)?.toString() ?: System.getenv(environmentName) ?: null
+	logger.info("getProperty($name): $environmentName - found=${!value.isNullOrBlank()}")
+	return value
 }


### PR DESCRIPTION
This PR adds the publish CI to GitHub Actions. It triggers for both tags and the master branch. The master branch will release "latest-SNAPSHOT" builds, tags release a build based on the git tag. It also updates the Azure CI to only publish the GitHub releases, my next PR will move that to GitHub too.

Additional changes:
  - Update POM (src: https://central.sonatype.org/pages/requirements.html)
  - Use getProperty util function so we can pass properties via environment variables
  - Add logging to getProperty function, useful for debugging (shown with `--info` parameter when invoking Gradle)
 - Default to emtpy string when signing password is null
